### PR TITLE
Some changes to models

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,10 +50,10 @@ A web application to collect information from child care providers in the State 
 This mono-repo consists of three main parts:
 1. Server, located in the root dir. The backend is an express server, with routes defined in `src/routes`
 1. Client, located in `client` dir. The frontend is a React SPA, created with create-react-app.
-1. Shared resources, located in `/shared` dir. The shared resources are installed in both the backend and frontend via [local path package.json dependencies](https://docs.npmjs.com/files/package.json#local-paths).
-To update the installed shared resources in server and client `node_modules`, do:
+1. Shared resources, located in `/shared` dir. The shared resources are included in the server by relative imports (e.g. from `src/index.ts`, import would be `import { XXXXXX } from '../shared/models'`).
+They are included in the react app via a local package installation (see `client/package.json`). Changes to shared need to be propagated to the client via a `yarn upgrade`. They are automatically present in the server.
+To update the copy of `shared` in the client:
 ```
-docker-compose exec server yarn upgrade file:./shared
 docker-compose exec client yarn upgrade file:../shared
 ```
 

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -15,5 +15,5 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": ["src", "../shared/models"]
+  "include": ["src"]
 }

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -9,9 +9,9 @@ module.exports = {
   synchronize: false,
   migrationsRun: true,
   logging: true,
-  entities: ['dist/entity/**/*.js'],
-  migrations: ['dist/migration/**/*.js'],
-  subscribers: ['dist/subscriber/**/*.js'],
+  entities: ['dist/src/entity/**/*.js'],
+  migrations: ['dist/src/migration/**/*.js'],
+  subscribers: ['dist/src/subscriber/**/*.js'],
   cli: {
     entitiesDir: 'src/entity',
     migrationsDir: 'src/migration',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "data-collection",
   "version": "0.0.1",
-  "main": "dist/index.js",
+  "main": "dist/src/index.js",
   "repository": "https://github.com/ctoec/data-collection.git",
   "license": "MIT",
   "dependencies": {
@@ -37,14 +37,14 @@
     "debug": "npm run build && npm run watch-debug",
     "prettier-all": "prettier --single-quote --write **/*.{js,jsx,ts,tsx,json,css,scss}",
     "prettier": "prettier --single-quote --write",
-    "serve": "node dist/index.js",
-    "serve-debug": "nodemon --inspect dist/index.js",
+    "serve": "node dist/src/index.js",
+    "serve-debug": "nodemon --inspect dist/src/index.js",
     "start": "npm run serve",
     "test": "exit 0",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js",
     "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\"",
     "watch-debug": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run serve-debug\"",
-    "watch-node": "nodemon dist/index.js",
+    "watch-node": "nodemon dist/src/index.js",
     "watch-test": "npm run test -- --watchAll",
     "watch-ts": "tsc -w"
   },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "nodemon": "^2.0.4",
     "pg": "^7.3.0",
     "reflect-metadata": "^0.1.10",
-    "shared": "file:./shared",
     "ts-node": "^8.10.2",
     "tsoa": "^3.2.1",
     "typeorm": "0.2.25",

--- a/shared/models/Child.ts
+++ b/shared/models/Child.ts
@@ -1,4 +1,10 @@
-import { Enrollment, Family, Gender, Organization } from '.';
+import {
+  Enrollment,
+  Family,
+  Gender,
+  Organization,
+  SpecialEducationServicesType,
+} from '.';
 
 export interface Child {
   id: string;
@@ -20,6 +26,8 @@ export interface Child {
   gender?: Gender;
   foster?: boolean;
   recievesC4K?: boolean;
+  recievesSpecialEducationServices?: boolean;
+  specialEducationServicesType?: SpecialEducationServicesType;
   family: Family;
   organization?: Organization;
   enrollments?: Array<Enrollment>;

--- a/shared/models/Family.ts
+++ b/shared/models/Family.ts
@@ -2,8 +2,7 @@ import { Child, IncomeDetermination, Organization } from '.';
 
 export interface Family {
   id: number;
-  addressLine1?: string;
-  addressLine2?: string;
+  streetAddress?: string;
   town?: string;
   state?: string;
   zip?: string;

--- a/shared/models/Gender.ts
+++ b/shared/models/Gender.ts
@@ -3,5 +3,5 @@ export enum Gender {
   Female = 'Female',
   Nonbinary = 'Nonbinary',
   Unknown = 'Unknown',
-  Unspecified = 'Unspecified',
+  NotSpecified = 'Not Specified',
 }

--- a/shared/models/SpecialEducationServicesType.ts
+++ b/shared/models/SpecialEducationServicesType.ts
@@ -1,0 +1,4 @@
+export enum SpecialEducationServicesType {
+  LEA = 'LEA',
+  NonLEA = 'Non LEA',
+}

--- a/shared/models/index.ts
+++ b/shared/models/index.ts
@@ -18,4 +18,5 @@ export * from './Region';
 export * from './ReportingPeriod';
 export * from './Site';
 export * from './SitePermission';
+export * from './SpecialEducationServicesType';
 export * from './User';

--- a/src/entity/Child.ts
+++ b/src/entity/Child.ts
@@ -10,7 +10,7 @@ import {
   Child as ChildInterface,
   Gender,
   SpecialEducationServicesType,
-} from 'shared/models';
+} from '../../shared/models';
 
 import { Enrollment } from './Enrollment';
 import { Family } from './Family';

--- a/src/entity/Child.ts
+++ b/src/entity/Child.ts
@@ -6,11 +6,14 @@ import {
   OneToMany,
 } from 'typeorm';
 
-import { Child as ChildInterface } from 'shared/models';
+import {
+  Child as ChildInterface,
+  Gender,
+  SpecialEducationServicesType,
+} from 'shared/models';
 
 import { Enrollment } from './Enrollment';
 import { Family } from './Family';
-import { Gender } from './enums/Gender';
 import { Organization } from './Organization';
 import { UpdateMetaData } from './embeddedColumns/UpdateMetaData';
 
@@ -72,6 +75,12 @@ export class Child implements ChildInterface {
 
   @Column({ default: false })
   recievesC4K?: boolean = false;
+
+  @Column({ nullable: true })
+  recievesSpecialEducationServices?: boolean;
+
+  @Column({ nullable: true, type: 'enum', enum: SpecialEducationServicesType })
+  specialEducationServicesType?: SpecialEducationServicesType;
 
   @ManyToOne((type) => Family, { nullable: false })
   family: Family;

--- a/src/entity/Enrollment.ts
+++ b/src/entity/Enrollment.ts
@@ -6,9 +6,8 @@ import {
   OneToMany,
 } from 'typeorm';
 
-import { Enrollment as EnrollmentInterface } from 'shared/models';
+import { Enrollment as EnrollmentInterface, AgeGroup } from 'shared/models';
 
-import { AgeGroup } from './enums/AgeGroup';
 import { Child } from './Child';
 import { Funding } from './Funding';
 import { Site } from './Site';

--- a/src/entity/Enrollment.ts
+++ b/src/entity/Enrollment.ts
@@ -6,7 +6,10 @@ import {
   OneToMany,
 } from 'typeorm';
 
-import { Enrollment as EnrollmentInterface, AgeGroup } from 'shared/models';
+import {
+  Enrollment as EnrollmentInterface,
+  AgeGroup,
+} from '../../shared/models';
 
 import { Child } from './Child';
 import { Funding } from './Funding';

--- a/src/entity/EnrollmentReport.ts
+++ b/src/entity/EnrollmentReport.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 
-import { EnrollmentReport as EnrollmentReportInterface } from 'shared/models';
+import { EnrollmentReport as EnrollmentReportInterface } from '../../shared/models';
 
 import { FlattenedEnrollment } from './FlattenedEnrollment';
 

--- a/src/entity/Family.ts
+++ b/src/entity/Family.ts
@@ -6,7 +6,7 @@ import {
   OneToMany,
 } from 'typeorm';
 
-import { Family as FamilyInterface } from 'shared/models';
+import { Family as FamilyInterface } from '../../shared/models';
 
 import { Organization } from './Organization';
 import { IncomeDetermination } from './IncomeDetermination';

--- a/src/entity/Family.ts
+++ b/src/entity/Family.ts
@@ -19,10 +19,7 @@ export class Family implements FamilyInterface {
   id: number;
 
   @Column({ nullable: true })
-  addressLine1?: string;
-
-  @Column({ nullable: true })
-  addressLine2?: string;
+  streetAddress?: string;
 
   @Column({ nullable: true })
   town?: string;

--- a/src/entity/FlattenedEnrollment.ts
+++ b/src/entity/FlattenedEnrollment.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
 
-import { FlattenedEnrollment as FlattenedEnrollmentInterface } from 'shared/models';
+import { FlattenedEnrollment as FlattenedEnrollmentInterface } from '../../shared/models';
 
 import { EnrollmentReport } from './EnrollmentReport';
 import {

--- a/src/entity/Funding.ts
+++ b/src/entity/Funding.ts
@@ -1,12 +1,14 @@
 import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
 
+import { Funding as FundingInterface } from 'shared/models';
+
 import { Enrollment } from './Enrollment';
 import { ReportingPeriod } from './ReportingPeriod';
 import { FundingSpace } from './FundingSpace';
 import { UpdateMetaData } from './embeddedColumns/UpdateMetaData';
 
 @Entity()
-export class Funding {
+export class Funding implements FundingInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/entity/Funding.ts
+++ b/src/entity/Funding.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, ManyToOne, Column } from 'typeorm';
 
-import { Funding as FundingInterface } from 'shared/models';
+import { Funding as FundingInterface } from '../../shared/models';
 
 import { Enrollment } from './Enrollment';
 import { ReportingPeriod } from './ReportingPeriod';

--- a/src/entity/FundingSpace.ts
+++ b/src/entity/FundingSpace.ts
@@ -6,12 +6,18 @@ import {
   OneToOne,
 } from 'typeorm';
 
+import {
+  FundingSpace as FundingSpaceInterface,
+  FundingSource,
+  FundingTime,
+  AgeGroup,
+} from 'shared/models';
+
 import { Organization } from './Organization';
-import { FundingSource, FundingTime, AgeGroup } from './enums';
 import { FundingTimeSplit } from './FundingTimeSplit';
 
 @Entity()
-export class FundingSpace {
+export class FundingSpace implements FundingSpaceInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/entity/FundingSpace.ts
+++ b/src/entity/FundingSpace.ts
@@ -11,7 +11,7 @@ import {
   FundingSource,
   FundingTime,
   AgeGroup,
-} from 'shared/models';
+} from '../../shared/models';
 
 import { Organization } from './Organization';
 import { FundingTimeSplit } from './FundingTimeSplit';

--- a/src/entity/FundingTimeSplit.ts
+++ b/src/entity/FundingTimeSplit.ts
@@ -1,8 +1,11 @@
 import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+
+import { FundingTimeSplit as FundingTimeSplitInterface } from 'shared/models';
+
 import { FundingSpace } from './FundingSpace';
 
 @Entity()
-export class FundingTimeSplit {
+export class FundingTimeSplit implements FundingTimeSplitInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/entity/FundingTimeSplit.ts
+++ b/src/entity/FundingTimeSplit.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
 
-import { FundingTimeSplit as FundingTimeSplitInterface } from 'shared/models';
+import { FundingTimeSplit as FundingTimeSplitInterface } from '../../shared/models';
 
 import { FundingSpace } from './FundingSpace';
 

--- a/src/entity/IncomeDetermination.ts
+++ b/src/entity/IncomeDetermination.ts
@@ -1,6 +1,6 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 
-import { IncomeDetermination as IncomeDeterminationInterface } from 'shared/models';
+import { IncomeDetermination as IncomeDeterminationInterface } from '../../shared/models';
 
 import { Family } from './Family';
 import { UpdateMetaData } from './embeddedColumns/UpdateMetaData';

--- a/src/entity/IncomeDetermination.ts
+++ b/src/entity/IncomeDetermination.ts
@@ -1,10 +1,12 @@
 import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
 
+import { IncomeDetermination as IncomeDeterminationInterface } from 'shared/models';
+
 import { Family } from './Family';
 import { UpdateMetaData } from './embeddedColumns/UpdateMetaData';
 
 @Entity()
-export class IncomeDetermination {
+export class IncomeDetermination implements IncomeDeterminationInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/entity/Organization.ts
+++ b/src/entity/Organization.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 
-import { Organization as OrganizationInterface } from 'shared/models';
+import { Organization as OrganizationInterface } from '../../shared/models';
 
 import { FundingSpace } from './FundingSpace';
 import { Site } from './Site';

--- a/src/entity/Organization.ts
+++ b/src/entity/Organization.ts
@@ -1,10 +1,12 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 
+import { Organization as OrganizationInterface } from 'shared/models';
+
 import { FundingSpace } from './FundingSpace';
 import { Site } from './Site';
 
 @Entity()
-export class Organization {
+export class Organization implements OrganizationInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/entity/Permission.ts
+++ b/src/entity/Permission.ts
@@ -5,6 +5,12 @@ import {
   ManyToOne,
   ChildEntity,
 } from 'typeorm';
+
+import {
+  SitePermission as SitePermissionInterface,
+  OrganizationPermission as OrganizationPermissionInterface,
+} from 'shared/models';
+
 import { User } from './User';
 import { Organization } from './Organization';
 import { Site } from './Site';
@@ -25,13 +31,15 @@ export abstract class Permission {
 }
 
 @ChildEntity(PermissionType.Organization)
-export class OrganizationPermission extends Permission {
+export class OrganizationPermission extends Permission
+  implements OrganizationPermissionInterface {
   @ManyToOne((type) => Organization)
   organization: Organization;
 }
 
 @ChildEntity(PermissionType.Site)
-export class SitePermission extends Permission {
+export class SitePermission extends Permission
+  implements SitePermissionInterface {
   @ManyToOne((type) => Site)
   site: Site;
 }

--- a/src/entity/Permission.ts
+++ b/src/entity/Permission.ts
@@ -9,7 +9,7 @@ import {
 import {
   SitePermission as SitePermissionInterface,
   OrganizationPermission as OrganizationPermissionInterface,
-} from 'shared/models';
+} from '../../shared/models';
 
 import { User } from './User';
 import { Organization } from './Organization';

--- a/src/entity/ReportingPeriod.ts
+++ b/src/entity/ReportingPeriod.ts
@@ -3,7 +3,7 @@ import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 import {
   ReportingPeriod as ReportingPeriodInterface,
   FundingSource,
-} from 'shared/models';
+} from '../../shared/models';
 
 @Entity()
 export class ReportingPeriod implements ReportingPeriodInterface {

--- a/src/entity/ReportingPeriod.ts
+++ b/src/entity/ReportingPeriod.ts
@@ -1,9 +1,12 @@
 import { Entity, Column, PrimaryGeneratedColumn } from 'typeorm';
 
-import { FundingSource } from './enums';
+import {
+  ReportingPeriod as ReportingPeriodInterface,
+  FundingSource,
+} from 'shared/models';
 
 @Entity()
-export class ReportingPeriod {
+export class ReportingPeriod implements ReportingPeriodInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/entity/Site.ts
+++ b/src/entity/Site.ts
@@ -6,12 +6,13 @@ import {
   OneToMany,
 } from 'typeorm';
 
+import { Site as SiteInterface, Region } from 'shared/models';
+
 import { Enrollment } from './Enrollment';
 import { Organization } from './Organization';
-import { Region } from './enums';
 
 @Entity()
-export class Site {
+export class Site implements SiteInterface {
   @PrimaryGeneratedColumn()
   id: number;
 

--- a/src/entity/Site.ts
+++ b/src/entity/Site.ts
@@ -6,7 +6,7 @@ import {
   OneToMany,
 } from 'typeorm';
 
-import { Site as SiteInterface, Region } from 'shared/models';
+import { Site as SiteInterface, Region } from '../../shared/models';
 
 import { Enrollment } from './Enrollment';
 import { Organization } from './Organization';

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,10 +1,12 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 
+import { User as UserInterface } from 'shared/models';
+
 import { OrganizationPermission, SitePermission } from './Permission';
 import { Site } from './Site';
 
 @Entity()
-export class User {
+export class User implements UserInterface {
   @PrimaryGeneratedColumn()
   id: number;
   @Column()

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -1,6 +1,6 @@
 import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
 
-import { User as UserInterface } from 'shared/models';
+import { User as UserInterface } from '../../shared/models';
 
 import { OrganizationPermission, SitePermission } from './Permission';
 import { Site } from './Site';

--- a/src/entity/decorators/dataDefinition.ts
+++ b/src/entity/decorators/dataDefinition.ts
@@ -1,5 +1,5 @@
 import 'reflect-metadata';
-import { DataDefinitionInfo as DataDefinitionInfoInterface } from 'shared/models';
+import { DataDefinitionInfo as DataDefinitionInfoInterface } from '../../../shared/models';
 
 // Formats
 export const BOOLEAN_FORMAT = 'Yes, Y, No, N';

--- a/src/migration/1597692652273-AlterChildAlterFamilyMatchDataCollection.ts
+++ b/src/migration/1597692652273-AlterChildAlterFamilyMatchDataCollection.ts
@@ -1,0 +1,62 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterChildAlterFamilyMatchDataCollection1597692652273
+  implements MigrationInterface {
+  name = 'AlterChildAlterFamilyMatchDataCollection1597692652273';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "family" DROP COLUMN "addressLine1"`);
+    await queryRunner.query(`ALTER TABLE "family" DROP COLUMN "addressLine2"`);
+    await queryRunner.query(
+      `ALTER TABLE "family" ADD "streetAddress" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "child" ADD "recievesSpecialEducationServices" boolean`
+    );
+    await queryRunner.query(
+      `CREATE TYPE "child_specialeducationservicestype_enum" AS ENUM('LEA', 'Non LEA')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "child" ADD "specialEducationServicesType" "child_specialeducationservicestype_enum"`
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."child_gender_enum" RENAME TO "child_gender_enum_old"`
+    );
+    await queryRunner.query(
+      `CREATE TYPE "child_gender_enum" AS ENUM('Male', 'Female', 'Nonbinary', 'Unknown', 'Not Specified')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "child" ALTER COLUMN "gender" TYPE "child_gender_enum" USING "gender"::"text"::"child_gender_enum"`
+    );
+    await queryRunner.query(`DROP TYPE "child_gender_enum_old"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "child_gender_enum_old" AS ENUM('Male', 'Female', 'Nonbinary', 'Unknown', 'Unspecified')`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "child" ALTER COLUMN "gender" TYPE "child_gender_enum_old" USING "gender"::"text"::"child_gender_enum_old"`
+    );
+    await queryRunner.query(`DROP TYPE "child_gender_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "child_gender_enum_old" RENAME TO  "child_gender_enum"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "child" DROP COLUMN "specialEducationServicesType"`
+    );
+    await queryRunner.query(
+      `DROP TYPE "child_specialeducationservicestype_enum"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "child" DROP COLUMN "recievesSpecialEducationServices"`
+    );
+    await queryRunner.query(`ALTER TABLE "family" DROP COLUMN "streetAddress"`);
+    await queryRunner.query(
+      `ALTER TABLE "family" ADD "addressLine2" character varying`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "family" ADD "addressLine1" character varying`
+    );
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,5 +21,5 @@
 
     "forceConsistentCasingInFileNames": true
   },
-  "include": ["src/**/*"]
+  "include": ["src"]
 }


### PR DESCRIPTION
- enums are only defined in shared/models/enums, not also in server
- renamed Unspecified to NotSpecified so that all gender enum options
start with a different letter, which makes parsing the
FlattenedEnrollment into child a little bit easier and why not
- server now transpiles shared node_module because it was all of a
sudden getting mad and unable to find the module without this
- so, updates references to built `dist/` resources to be at `dist/src`
- adds special ed fields to child
- condenses addressLine1 and addressLine2 into streetAddress on family
- makes all server entity models in `src/entity` extend the appropriate interfaces from
`shared/models`