### PR TITLE
Added new funding types to enums

### DIFF
--- a/shared/models/FundingSource.ts
+++ b/shared/models/FundingSource.ts
@@ -1,6 +1,5 @@
 export enum FundingSource {
   CDC = 'CDC',
-  SchoolReadiness = 'SchoolReadiness',
   CSR = 'CSR',
   PSR = 'PSR',
   SHS = 'SHS',

--- a/shared/models/FundingSource.ts
+++ b/shared/models/FundingSource.ts
@@ -3,4 +3,6 @@ export enum FundingSource {
   SchoolReadiness = 'SchoolReadiness',
   CSR = 'CSR',
   PSR = 'PSR',
+  SHS = 'SHS',
+  SS = 'SS',
 }

--- a/shared/models/FundingTime.ts
+++ b/shared/models/FundingTime.ts
@@ -2,6 +2,7 @@ export enum FundingTime {
   Full = 'Full',
   Part = 'Part',
   Split = 'Split',
-  Extended = 'Extended',
+  ExtendedDay = 'ExtendedDay',
+  ExtendedYear = 'ExtendedYear',
   School = 'School',
 }

--- a/src/entity/enums/AgeGroup.ts
+++ b/src/entity/enums/AgeGroup.ts
@@ -1,5 +1,0 @@
-export enum AgeGroup {
-  InfantToddler = 'InfantToddler',
-  Preschool = 'Preschool',
-  SchoolAge = 'SchoolAge',
-}

--- a/src/entity/enums/FundingSource.ts
+++ b/src/entity/enums/FundingSource.ts
@@ -1,8 +1,0 @@
-export enum FundingSource {
-  CDC = 'CDC',
-  SchoolReadiness = 'SchoolReadiness',
-  CSR = 'CSR',
-  PSR = 'PSR',
-  SHS = 'SHS',
-  SS = 'SS',
-}

--- a/src/entity/enums/FundingSource.ts
+++ b/src/entity/enums/FundingSource.ts
@@ -3,4 +3,6 @@ export enum FundingSource {
   SchoolReadiness = 'SchoolReadiness',
   CSR = 'CSR',
   PSR = 'PSR',
+  SHS = 'SHS',
+  SS = 'SS',
 }

--- a/src/entity/enums/FundingTime.ts
+++ b/src/entity/enums/FundingTime.ts
@@ -1,8 +1,0 @@
-export enum FundingTime {
-  Full = 'Full',
-  Part = 'Part',
-  Split = 'Split',
-  ExtendedDay = 'ExtendedDay',
-  ExtendedYear = 'ExtendedYear',
-  School = 'School',
-}

--- a/src/entity/enums/FundingTime.ts
+++ b/src/entity/enums/FundingTime.ts
@@ -2,6 +2,7 @@ export enum FundingTime {
   Full = 'Full',
   Part = 'Part',
   Split = 'Split',
-  Extended = 'Extended',
+  ExtendedDay = 'ExtendedDay',
+  ExtendedYear = 'ExtendedYear',
   School = 'School',
 }

--- a/src/entity/enums/Gender.ts
+++ b/src/entity/enums/Gender.ts
@@ -1,7 +1,0 @@
-export enum Gender {
-  Male = 'Male',
-  Female = 'Female',
-  Nonbinary = 'Nonbinary',
-  Unknown = 'Unknown',
-  Unspecified = 'Unspecified',
-}

--- a/src/entity/enums/Region.ts
+++ b/src/entity/enums/Region.ts
@@ -1,7 +1,0 @@
-export enum Region {
-  East = 'East',
-  NorthCentral = 'NorthCentral',
-  NorthWest = 'NorthWest',
-  SouthCentral = 'SouthCentral',
-  SouthWest = 'SouthWest',
-}

--- a/src/entity/enums/index.ts
+++ b/src/entity/enums/index.ts
@@ -1,5 +1,0 @@
-export * from './AgeGroup';
-export * from './FundingSource';
-export * from './FundingTime';
-export * from './Gender';
-export * from './Region';


### PR DESCRIPTION
Closes #121 and Closes #122 
It looks like there isn't any standardization between the funding times of various funding sources. For example, different funding sources reference "full day" and "school day," which sound like the same thing but are currently treated separately. Same thing with "expanded day." I'm guessing this is an artifact of the agencies / funding sources rather than something by design on our end, but should we be handling this in any specific way? As in, is it feasible for us to consolidate these different names for the same things down into one 'type' (i.e. full day and school day both now just refer to 'full day')?