### PR TITLE
Remove local port mapping of React app

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,8 +8,6 @@ services:
       - ./client:/home/node/app:cached
       - ./shared:/home/node/shared:cached
     working_dir: /home/node/app
-    ports:
-      - 5000:3000
     entrypoint:
       - yarn
       - start


### PR DESCRIPTION
Within local development, Express serves the React app based on the host/port as it exists _within the Docker container_ (3000).  And because we don't use Docker anywhere but during local development, there's no need to expose the static React app outside of the container.  (It can also cause confusion as to what the actual entrypoint to the application should be 😅)