### PR TITLE
Skeleton tabnav to put forms in

### DIFF
--- a/client/src/containers/CheckData/CheckData.tsx
+++ b/client/src/containers/CheckData/CheckData.tsx
@@ -13,6 +13,9 @@ import {
   Button,
   Table,
   Column,
+  TextInput,
+  ExpandRow,
+  TabNav,
 } from '@ctoec/component-library';
 import { ReactComponent as Arrow } from '@ctoec/component-library/dist/assets/images/arrowRight.svg';
 import { ProcessStep } from '@ctoec/component-library/dist/components/ProcessList/ProcessStep';

--- a/client/src/containers/CheckData/CheckData.tsx
+++ b/client/src/containers/CheckData/CheckData.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState, useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, Link } from 'react-router-dom';
 import queryString from 'query-string';
 import pluralize from 'pluralize';
 import moment from 'moment';
@@ -13,11 +13,9 @@ import {
   Button,
   Table,
   Column,
-  TextInput,
-  ExpandRow,
 } from '@ctoec/component-library';
-import { TabNav } from './TabNav';
 import { ReactComponent as Arrow } from '@ctoec/component-library/dist/assets/images/arrowRight.svg';
+import { ProcessStep } from '@ctoec/component-library/dist/components/ProcessList/ProcessStep';
 
 const CheckData: React.FC = () => {
   const reportId = parseInt(
@@ -52,17 +50,27 @@ const CheckData: React.FC = () => {
       name: columnMeta.formattedName,
       title: columnMeta.propertyName,
       cell: ({ row }) => {
-        // special case for clickable name column that expands row
+        // special case for clickable name column that sends user to edit page
         if (columnMeta.propertyName === 'name') {
           return (
             <td>
-              <ExpandRow>
+
+              // Pass reportId to save/send data back once editing is done
+              <Link to={
+                {
+                  pathname: "/edit-record/" + row.name,
+                  state: {
+                    'reportId': reportId,
+                    'childName': row.name,
+                  },
+                }
+              }>
                 <Button
                   className="text-no-wrap"
                   appearance="unstyled"
                   text={row.name || ''}
                 />
-              </ExpandRow>
+              </Link>
             </td>
           );
         }
@@ -107,58 +115,6 @@ const CheckData: React.FC = () => {
                 rowKey={(row) => row.id}
                 data={reportData}
                 columns={tableColumns}
-
-                rowExpansionRender={(row) => (
-                  <div className="grid-row flex-row">
-                    <div >
-                      <h3>Edit information about {row.name} </h3>
-
-                      <div >
-                        <TabNav
-                            items={[
-
-                              // TODO: Each of these can be refactored into a form element that
-                              // we store somewhere in the repo and just call here. This is
-                              // just a placeholder as we develop the forms.
-                                {
-                                    id: "child-tab",
-                                    text: "Child Info",
-                                    content: <span>This is where the child info form goes</span>
-                                },
-                                {
-                                    id: "family-tab",
-                                    text: "Family Info",
-                                    content: <span>This is where the family info form goes</span>
-                                },
-                                {
-                                    id: "income-tab",
-                                    text: "Family Income",
-                                    content: <span>This is where the family income form goes</span>
-                                },
-                                {
-                                    id: "enrollment-tab",
-                                    text: "Enrollment and funding",
-                                    content: <span>This is where the enrollment form goes</span>
-                                },
-                                {
-                                    id: "care-tab",
-                                    text: "Care 4 Kids",
-                                    content: <span>This is where the care for kids form goes</span>
-                                }
-                            ]}
-                            activeId="child-tab"
-                        />
-                      </div>
-                      <div className="margin-bottom-2"></div>
-                    <div className="margin-bottom-2">
-                      <ExpandRow>
-                        <Button text="CLOSE THIS EXPANSION" />
-                      </ExpandRow>
-                    </div>
-                    </div>
-                  </div>
-                )}
-                
               />
             </PerfectScrollbar>
           ) : (

--- a/client/src/containers/CheckData/CheckData.tsx
+++ b/client/src/containers/CheckData/CheckData.tsx
@@ -16,6 +16,7 @@ import {
   TextInput,
   ExpandRow,
 } from '@ctoec/component-library';
+import { TabNav } from './TabNav';
 import { ReactComponent as Arrow } from '@ctoec/component-library/dist/assets/images/arrowRight.svg';
 
 const CheckData: React.FC = () => {
@@ -106,28 +107,58 @@ const CheckData: React.FC = () => {
                 rowKey={(row) => row.id}
                 data={reportData}
                 columns={tableColumns}
+
                 rowExpansionRender={(row) => (
                   <div className="grid-row flex-row">
-                    <div className="grid-col-1">
-                      <h3>Edit the stuff about {row.name} </h3>
-                      <TextInput
-                        label="An input can go here"
-                        id="text-input"
-                        type="input"
-                        onChange={() => {}}
-                      />
-                      <Button
-                        className="margin-top-2"
-                        text="A button can go here"
-                      />
-                    </div>
-                    <div className="grid-col-1">
+                    <div >
+                      <h3>Edit information about {row.name} </h3>
+
+                      <div >
+                        <TabNav
+                            items={[
+
+                              // TODO: Each of these can be refactored into a form element that
+                              // we store somewhere in the repo and just call here. This is
+                              // just a placeholder as we develop the forms.
+                                {
+                                    id: "child-tab",
+                                    text: "Child Info",
+                                    content: <span>This is where the child info form goes</span>
+                                },
+                                {
+                                    id: "family-tab",
+                                    text: "Family Info",
+                                    content: <span>This is where the family info form goes</span>
+                                },
+                                {
+                                    id: "income-tab",
+                                    text: "Family Income",
+                                    content: <span>This is where the family income form goes</span>
+                                },
+                                {
+                                    id: "enrollment-tab",
+                                    text: "Enrollment and funding",
+                                    content: <span>This is where the enrollment form goes</span>
+                                },
+                                {
+                                    id: "care-tab",
+                                    text: "Care 4 Kids",
+                                    content: <span>This is where the care for kids form goes</span>
+                                }
+                            ]}
+                            activeId="child-tab"
+                        />
+                      </div>
+                      <div className="margin-bottom-2"></div>
+                    <div className="margin-bottom-2">
                       <ExpandRow>
                         <Button text="CLOSE THIS EXPANSION" />
                       </ExpandRow>
                     </div>
+                    </div>
                   </div>
                 )}
+                
               />
             </PerfectScrollbar>
           ) : (

--- a/client/src/containers/EditRecord/EditRecord.tsx
+++ b/client/src/containers/EditRecord/EditRecord.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+
+import { TabNav } from '@ctoec/component-library';
+
+const EditRecord: React.FC = () => {
+    const record = useLocation().state['childName'];
+    const reportId = useLocation().state['reportId'];
+    return (
+        <div className='grid-container'>
+            <div className='margin-top-4'>
+                <h2>Edit information for {record}</h2>
+            </div>
+                <TabNav
+                    items={[
+
+                        // TODO: Each of these can be refactored into a form element that
+                        // we store somewhere in the repo and just call here. This is
+                        // just a placeholder as we develop the forms.
+                        {
+                            id: "child-tab",
+                            text: "Child Info",
+                            content: <span>This is where the child info form goes</span>
+                        },
+                        {
+                            id: "family-tab",
+                            text: "Family Info",
+                            content: <span>This is where the family info form goes</span>
+                        },
+                        {
+                            id: "income-tab",
+                            text: "Family Income",
+                            content: <span>This is where the family income form goes</span>
+                        },
+                        {
+                            id: "enrollment-tab",
+                            text: "Enrollment and funding",
+                            content: <span>This is where the enrollment form goes</span>
+                        },
+                        {
+                            id: "care-tab",
+                            text: "Care 4 Kids",
+                            content: <span>This is where the care for kids form goes</span>
+                        }
+                    ]}
+                    activeId="child-tab"
+                />
+            </div>
+    );
+
+};
+
+export default EditRecord;

--- a/client/src/contexts/AuthenticationContext/AuthenticationContext.tsx
+++ b/client/src/contexts/AuthenticationContext/AuthenticationContext.tsx
@@ -22,7 +22,6 @@ import { getCurrentHost } from '../../utils/getCurrentHost';
 
 export type AuthenticationContextType = {
   accessToken: string | null;
-  withFreshToken: () => Promise<void>;
   loading: boolean;
 };
 
@@ -42,7 +41,6 @@ export type AuthenticationProviderPropsType = {
 
 const AuthenticationContext = React.createContext<AuthenticationContextType>({
   accessToken: null,
-  withFreshToken: async () => {},
   loading: true,
 });
 
@@ -246,6 +244,13 @@ const AuthenticationProvider: React.FC<AuthenticationProviderPropsType> = ({
     redirectUrl,
   ]);
 
+  // ensure token is always fresh
+  // (function exits early if token is still valid
+  // -- only does request if necessary)
+  useEffect(() => {
+    makeRefreshTokenRequest();
+  });
+
   /**
    * Create and perform authorization code-based token request.
    * This type of token request is only executed after the initial auth request,
@@ -312,7 +317,6 @@ const AuthenticationProvider: React.FC<AuthenticationProviderPropsType> = ({
     <Provider
       value={{
         accessToken: accessToken,
-        withFreshToken: makeRefreshTokenRequest,
         loading: loading,
       }}
     >

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -5,6 +5,7 @@ import PageNotFound from './containers/PageNotFound/PageNotFound';
 import Upload from './containers/Upload/Upload';
 import GettingStarted from './containers/GettingStarted/GettingStarted';
 import CheckData from './containers/CheckData/CheckData';
+import EditRecord from './containers/EditRecord/EditRecord';
 import DataDefinitions from './containers/DataDefinitions/DataDefinitions';
 import SubmitSuccess from './containers/SubmitSuccess/SubmitSuccess';
 
@@ -52,6 +53,11 @@ export const routes: RouteConfig[] = [
   {
     path: '/check-data',
     component: CheckData,
+    unauthorized: false,
+  },
+  {
+    path: '/edit-record',
+    component: EditRecord,
     unauthorized: false,
   },
   {


### PR DESCRIPTION
Assuming the TabNav PR in the component library gets approved, here's the blank field form navigation from the edit roster page. UI is a work in progress but this at least lets us start getting forms created. Also, as we make them, we can refactor the currently hardcode TabNavProps objects in the middle of CheckData to be their own module entities.

<img width="1335" alt="Screen Shot 2020-08-20 at 12 21 03 PM" src="https://user-images.githubusercontent.com/49412165/90798618-28021c00-e2e0-11ea-841e-3eb549daba33.png">
