### PR TITLE
Persists parsed flattened enrollment data to DB

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "@types/react-router-dom": "^5.1.5",
     "content-disposition": "^0.5.3",
     "file-saver": "^2.0.2",
+    "idx": "^2.5.6",
     "moment": "^2.27.0",
     "node-sass": "yarn:sass",
     "pluralize": "^8.0.0",

--- a/client/src/containers/CheckData/CheckData.tsx
+++ b/client/src/containers/CheckData/CheckData.tsx
@@ -5,35 +5,16 @@ import PerfectScrollbar from 'react-perfect-scrollbar';
 import 'react-perfect-scrollbar/dist/css/styles.css';
 import AuthenticationContext from '../../contexts/AuthenticationContext/AuthenticationContext';
 import { apiGet } from '../../utils/api';
-import {
-  Organization,
-  Site,
-  Child,
-  Family,
-  IncomeDetermination,
-  Enrollment,
-  Funding,
-} from 'shared/models';
-import { TextWithIcon, Button, Table, Column } from '@ctoec/component-library';
+import { Child } from 'shared/models';
+import { TextWithIcon, Button, Table } from '@ctoec/component-library';
 import { ReactComponent as Arrow } from '@ctoec/component-library/dist/assets/images/arrowRight.svg';
 import { tableColumns } from './TableColumns';
-
-export type TableRow = {
-  rowId: number;
-  organization: Organization;
-  site: Site;
-  child: Child;
-  family?: Family;
-  incomeDetermination?: IncomeDetermination;
-  enrollment?: Enrollment;
-  funding?: Funding;
-};
 
 const CheckData: React.FC = () => {
   const { reportId } = useParams();
 
   const { accessToken } = useContext(AuthenticationContext);
-  const [reportData, setReportData] = useState<TableRow[]>([]);
+  const [reportData, setReportData] = useState<Child[]>([]);
 
   useEffect(() => {
     if (reportId && accessToken) {
@@ -69,11 +50,11 @@ const CheckData: React.FC = () => {
           <p>If everything looks good, submit to OEC.</p>
           {reportData.length ? (
             <PerfectScrollbar>
-              <Table<TableRow>
+              <Table<Child>
                 id="enrollment-report-table"
-                rowKey={(row) => row.child.id}
+                rowKey={(row) => row.id}
                 data={reportData}
-                columns={tableColumns(reportId)}
+                columns={tableColumns()}
               />
             </PerfectScrollbar>
           ) : (

--- a/client/src/containers/CheckData/TableColumns.tsx
+++ b/client/src/containers/CheckData/TableColumns.tsx
@@ -1,29 +1,28 @@
-import { Column, Button } from '@ctoec/component-library';
-import { Link } from 'react-router-dom';
 import React from 'react';
-import { TableRow } from './CheckData';
+import idx from 'idx';
+import { Link } from 'react-router-dom';
+import { Column, Button } from '@ctoec/component-library';
+import { Child } from 'shared/models';
 
 const tableColumnClassName = 'text-pre text-center font-body-2xs';
-export const tableColumns: (_: number) => Column<TableRow>[] = (
-  reportId: number
-) => {
+export const tableColumns: () => Column<Child>[] = () => {
   return [
     {
       className: tableColumnClassName,
       name: 'Name',
-      sort: (row) => row.child.lastName,
+      sort: (row) => row.lastName,
       cell: ({ row }) => {
         return (
           <td>
             <Link
               to={{
-                pathname: `/check-data/${reportId}/edit-record/${row.rowId}`,
+                pathname: `/edit-record/${row.id}`,
               }}
             >
               <Button
                 className="text-no-wrap font-body-2xs"
                 appearance="unstyled"
-                text={`${row.child.firstName} ${row.child.lastName}`}
+                text={`${row.firstName} ${row.lastName}`}
               />
             </Link>
           </td>
@@ -34,35 +33,43 @@ export const tableColumns: (_: number) => Column<TableRow>[] = (
       className: tableColumnClassName,
       name: 'Birth Date',
       cell: ({ row }) => (
-        <td>
-          {row.child.birthdate ? row.child.birthdate.format('MM/DD/YYYY') : ''}
-        </td>
+        <td>{row.birthdate ? row.birthdate.format('MM/DD/YYYY') : ''}</td>
       ),
     },
     {
       className: tableColumnClassName,
       name: 'Age group',
-      cell: ({ row }) => <td>{row.enrollment?.ageGroup}</td>,
+      cell: ({ row }) => <td>{idx(row, (_) => _.enrollments[0].ageGroup)}</td>,
     },
     {
       className: tableColumnClassName,
       name: 'Funding type',
-      cell: ({ row }) => <td>{row.funding?.fundingSpace.source}</td>,
+      cell: ({ row }) => (
+        <td>
+          {idx(row, (_) => _.enrollments[0].fundings[0].fundingSpace.source)}
+        </td>
+      ),
     },
     {
       className: tableColumnClassName,
       name: 'Contract space',
-      cell: ({ row }) => <td>{row.funding?.fundingSpace.time}</td>,
+      cell: ({ row }) => (
+        <td>
+          {idx(row, (_) => _.enrollments[0].fundings[0].fundingSpace.time)}
+        </td>
+      ),
     },
     {
       className: tableColumnClassName,
       name: 'Site',
-      cell: ({ row }) => <td>{row.site.name}</td>,
+      cell: ({ row }) => <td>{idx(row, (_) => _.enrollments[0].site.name)}</td>,
     },
     {
       className: tableColumnClassName,
       name: 'Enrollment date',
-      cell: ({ row }) => <td>{row.enrollment?.entry?.format('MM/DD/YYYY')}</td>,
+      cell: ({ row }) => (
+        <td>{idx(row, (_) => _.enrollments[0].entry.format('MM/DD/YYYY'))}</td>
+      ),
     },
   ];
 };

--- a/client/src/containers/EditRecord/EditRecord.tsx
+++ b/client/src/containers/EditRecord/EditRecord.tsx
@@ -2,27 +2,26 @@ import React, { useState, useContext, useEffect } from 'react';
 import { useParams } from 'react-router-dom';
 
 import { TabNav } from '@ctoec/component-library';
-import { TableRow } from '../CheckData/CheckData';
 import AuthenticationContext from '../../contexts/AuthenticationContext/AuthenticationContext';
 import { apiGet } from '../../utils/api';
+import { Child } from 'shared/models';
 
 const EditRecord: React.FC = () => {
-  const { reportId, rowId } = useParams();
+  const { childId } = useParams();
   const { accessToken } = useContext(AuthenticationContext);
-  const [rowData, setRowData] = useState<TableRow>();
+  const [rowData, setRowData] = useState<Child>();
 
   useEffect(() => {
-    apiGet(`enrollment-reports/${reportId}/row/${rowId}`, {
+    apiGet(`children/${childId}`, {
       accessToken,
     }).then((_rowData) => setRowData(_rowData));
-  }, [accessToken, reportId, rowId]);
+  }, [accessToken, childId]);
 
   return rowData ? (
     <div className="grid-container">
       <div className="margin-top-4">
         <h2>
-          Edit information for {rowData.child.firstName}{' '}
-          {rowData.child.lastName}
+          Edit information for {rowData.firstName} {rowData.lastName}
         </h2>
       </div>
       <TabNav

--- a/client/src/containers/Upload/Upload.tsx
+++ b/client/src/containers/Upload/Upload.tsx
@@ -32,9 +32,7 @@ const Upload: React.FC = () => {
       formData.set('file', file);
       apiPost('enrollment-reports', formData, { accessToken })
         .then((value) => {
-          history.push(
-            `check-data?${queryString.stringify({ reportId: value.id })}`
-          );
+          history.push(`check-data/${value.id}`);
         })
         .catch((err) => {
           setError(err);

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -57,7 +57,7 @@ export const routes: RouteConfig[] = [
     exact: true,
   },
   {
-    path: '/check-data/:reportId/edit-record/:rowId',
+    path: '/edit-record/:childId',
     component: EditRecord,
     unauthorized: false,
   },

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -5960,6 +5960,11 @@ identity-obj-proxy@3.0.0:
   dependencies:
     harmony-reflect "^1.4.6"
 
+idx@^2.5.6:
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/idx/-/idx-2.5.6.tgz#1f824595070100ae9ad585c86db08dc74f83a59d"
+  integrity sha512-WFXLF7JgPytbMgelpRY46nHz5tyDcedJ76pLV+RJWdb8h33bxFq4bdZau38DhNSzk5eVniBf1K3jwfK+Lb5nYA==
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"

--- a/src/entity/Child.ts
+++ b/src/entity/Child.ts
@@ -87,6 +87,9 @@ export class Child implements ChildInterface {
   @ManyToOne((type) => Family, { nullable: false })
   family: Family;
 
+  @Column()
+  familyId: number;
+
   @ManyToOne((type) => Organization, { nullable: false })
   organization?: Organization;
 

--- a/src/routes/children.ts
+++ b/src/routes/children.ts
@@ -1,0 +1,33 @@
+import express, { Response, Request } from 'express';
+import { getManager } from 'typeorm';
+import { Child } from '../entity';
+import { passAsyncError } from '../middleware/error/passAsyncError';
+import { NotFoundError } from '..//middleware/error/errors';
+
+export const childrenRouter = express.Router();
+
+/**
+ * /children/:childId GET
+ *
+ * Returns the given child, with all nested data desired by the client
+ * including family, incomeDeterminations, enrollments, and fundings
+ */
+childrenRouter.get(
+  '/:childId',
+  passAsyncError(async (req: Request, res: Response) => {
+    const childId = req.params['childId'];
+    const child = await getManager().findOne(Child, {
+      where: { id: childId },
+      relations: [
+        'family',
+        'family.incomeDeterminations',
+        'enrollments',
+        'enrollments.fundings',
+      ],
+    });
+
+    if (!child) throw new NotFoundError();
+
+    res.send(child);
+  })
+);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import { authenticate } from '../middleware/authenticate';
 import { router as userRouter } from './user';
 import { router as enrollmentReportRouter } from './enrollmentReport';
 import { columnMetadataRouter } from './columnMetadata';
+import { childrenRouter } from './children';
 
 export const router = express.Router();
 
@@ -13,3 +14,4 @@ router.use('/column-metadata', columnMetadataRouter);
 /* AUTHENTICATED ROUTES */
 router.use('/users', authenticate, userRouter);
 router.use('/enrollment-reports', authenticate, enrollmentReportRouter);
+router.use('/children', authenticate, childrenRouter);


### PR DESCRIPTION
Adds a DB save to the mapping step, and returns all data
as a nested child object, as opposed to a flat map of all object

Also adds an endpoint to GET a single child, and uses that for the
"Edit-Record" view

Also fixes client routing from upload to check data