### PR TITLE
Care4Kids Info Form

### DIFF
--- a/client/src/containers/EditRecord/EditRecord.tsx
+++ b/client/src/containers/EditRecord/EditRecord.tsx
@@ -5,6 +5,7 @@ import { TabNav } from '@ctoec/component-library';
 import AuthenticationContext from '../../contexts/AuthenticationContext/AuthenticationContext';
 import { apiGet } from '../../utils/api';
 import { Child } from 'shared/models';
+import { CareForKidsForm } from './Forms/CareForKidsForm';
 
 const EditRecord: React.FC = () => {
   const { childId } = useParams();
@@ -16,6 +17,15 @@ const EditRecord: React.FC = () => {
       accessToken,
     }).then((_rowData) => setRowData(_rowData));
   }, [accessToken, childId]);
+
+  // Wrapped method to hand off to child forms to allow lifting
+  // state back up to the EditRecord page. This is good because
+  // then only the EditRecord page has to make any calls to the
+  // database or API, allowing for a single, unfiied formulation
+  // here rather than individual forms.
+  function handleChange(newRow: Child) {
+    setRowData(newRow);
+  }
 
   return rowData ? (
     <div className="grid-container">
@@ -52,7 +62,7 @@ const EditRecord: React.FC = () => {
           {
             id: 'care-tab',
             text: 'Care 4 Kids',
-            content: <span>This is where the care for kids form goes</span>,
+            content: <CareForKidsForm initState={rowData} passData={handleChange} />
           },
         ]}
         activeId="child-tab"

--- a/client/src/containers/EditRecord/Forms/CareForKidsForm.tsx
+++ b/client/src/containers/EditRecord/Forms/CareForKidsForm.tsx
@@ -1,0 +1,82 @@
+import React, { useState } from 'react';
+import {
+    Form, 
+    FormSubmitButton,
+    FormField,
+    RadioButtonGroupProps,
+    RadioButtonGroup,
+    RadioButton } from '@ctoec/component-library';
+
+/*
+* Basic functional component designed to allow user to edit
+* the Care For Kids field of a data record.
+* Data is not processed using a FlattenedEnrollment.
+* Rather, information is inherited via props from the parent
+* object (the EditRecord page), which will bundle all 
+* edits together and make a single unified record update
+* when the user is done editing. This allows users to make
+* changes to the state of individual fields without needing
+* to make repeated calls to the databse via API methods.
+*/
+export const CareForKidsForm: React.FC = (props) => {
+
+    const [currentState, setcurrentState] = useState(props.initState);
+
+    // Updates only the changed information by using the object spread
+    // to only edit the form field value
+    function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+        e.preventDefault();
+        var newState = {...currentState};
+        newState['recievesC4K'] = e.target.value === 'Yes' ? true : false;
+        setcurrentState(newState);
+        return newState['recievesC4K'];
+    }
+
+    // Uses the inherited method from the parent on EditRecord to 
+    // change the *state* inherited from EditRecord. This form
+    // keeps a local copy of the state so that only changes the user
+    // wishes to commit are pushed back up to the parent.
+    function saveButton() {
+        console.log(currentState);
+        props.passData(currentState);
+        alert('Data saved successfully!');
+    }
+
+    return(
+        <div className='grid-container margin-top-2'>
+            <h2 className='grid-row'>Receiving Care For Kids?</h2>
+            <div>
+                <Form<object>
+                    className='CareForKidsForm'
+                    data={currentState}
+                    onSubmit={saveButton}
+                    noValidate
+                    autoComplete="off"
+                >
+                    <FormField<object, RadioButtonGroupProps, boolean>
+                        getValue={(data) => data.at('recievesC4K')}
+                        preprocessForDisplay={(data) => data == true ? 'yes' : 'no'}
+                        parseOnChangeEvent={(e) => handleChange(e)}
+                        inputComponent={RadioButtonGroup}
+                        id='c4k-radio-group'
+                        name='careforkids'
+                        legend=''
+                        options={[
+                            {
+                                render: (props) => <div><RadioButton text='Yes' {...props} /></div>,
+                                value: 'Yes'
+                            },
+                            {
+                                render: (props) => <div><RadioButton text='No' {...props} /></div>,
+                                value: 'No'
+                            }
+                        ]}
+                    / >
+                    <div className='grid-row margin-top-2'>
+                        <FormSubmitButton text="Save edits" />
+                    </div>
+                </ Form>
+            </div>
+        </div>
+    );
+};

--- a/client/src/containers/EditRecord/Forms/CareForKidsForm.tsx
+++ b/client/src/containers/EditRecord/Forms/CareForKidsForm.tsx
@@ -6,6 +6,12 @@ import {
     RadioButtonGroupProps,
     RadioButtonGroup,
     RadioButton } from '@ctoec/component-library';
+import { Child } from 'shared/models';
+
+type CareForKidsProps = {
+    initState: Child,
+    passData(_: Child): void;
+}
 
 /*
 * Basic functional component designed to allow user to edit
@@ -18,27 +24,15 @@ import {
 * changes to the state of individual fields without needing
 * to make repeated calls to the databse via API methods.
 */
-export const CareForKidsForm: React.FC = (props) => {
-
-    const [currentState, setcurrentState] = useState(props.initState);
-
-    // Updates only the changed information by using the object spread
-    // to only edit the form field value
-    function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
-        e.preventDefault();
-        var newState = {...currentState};
-        newState['recievesC4K'] = e.target.value === 'Yes' ? true : false;
-        setcurrentState(newState);
-        return newState['recievesC4K'];
-    }
+export const CareForKidsForm: React.FC<CareForKidsProps> = 
+    ({initState, passData}) => {
 
     // Uses the inherited method from the parent on EditRecord to 
     // change the *state* inherited from EditRecord. This form
     // keeps a local copy of the state so that only changes the user
     // wishes to commit are pushed back up to the parent.
-    function saveButton() {
-        console.log(currentState);
-        props.passData(currentState);
+    function saveButton(newState: Child) {
+        passData(newState);
         alert('Data saved successfully!');
     }
 
@@ -48,15 +42,15 @@ export const CareForKidsForm: React.FC = (props) => {
             <div>
                 <Form<object>
                     className='CareForKidsForm'
-                    data={currentState}
+                    data={initState}
                     onSubmit={saveButton}
                     noValidate
                     autoComplete="off"
                 >
-                    <FormField<object, RadioButtonGroupProps, boolean>
+                    <FormField<Child, RadioButtonGroupProps, boolean>
                         getValue={(data) => data.at('recievesC4K')}
                         preprocessForDisplay={(data) => data == true ? 'yes' : 'no'}
-                        parseOnChangeEvent={(e) => handleChange(e)}
+                        parseOnChangeEvent={(e) => {return e.target.value === 'Yes'}}
                         inputComponent={RadioButtonGroup}
                         id='c4k-radio-group'
                         name='careforkids'


### PR DESCRIPTION
Not ready to merge, but like Melanie, I thought it would be good to get this up where it can be seen. I know we're blocked on the ticket because of the API, but if we're happy with this way of storing change back in the object I'll move forward with that (the idea is that while the individual Forms in the TabNav can save fields in the Child object representing a row, the EditRecord page will have a button below all the forms for Save & Return to CheckData that will handle the API PUT request).