### PR TITLE
Add service for funding-spaces

### DIFF
--- a/src/controllers/fundingSpaces.ts
+++ b/src/controllers/fundingSpaces.ts
@@ -1,0 +1,27 @@
+import { User, FundingSpace, Site, Organization } from '../entity';
+import { getManager, In } from 'typeorm';
+
+/**
+ * Get all funding spaces a given user has access to,
+ * including those for organizations the user has
+ * permissions for, and those for organizations that
+ * own the sites the user has permissions for
+ * @param user
+ */
+export const getFundingSpaces = async (user: User) => {
+  // get org ids for the sites the user can access
+  const siteOrgIds = (
+    await getManager().find(Site, {
+      where: { organization: In(user.siteIds || []) },
+    })
+  ).map((site) => site.organizationId);
+
+  // create list of distinct organizations the user
+  // can access funding spaces for
+  const orgIds = Array.from(new Set([...siteOrgIds, ...user.organizationIds]));
+
+  return getManager().find(FundingSpace, {
+    where: { organization: { id: In(orgIds) } },
+    relations: ['organization'],
+  });
+};

--- a/src/controllers/sites.ts
+++ b/src/controllers/sites.ts
@@ -1,65 +1,15 @@
-import { User, Site } from '../entity';
+import { User, Site, Organization } from '../entity';
 import { getManager } from 'typeorm';
 
-export const getSites = async (
-  user: User,
-  siteIds: number[] = [],
-  organizationIds: number[] = [],
-  communityIds: number[] = []
-) => {
-  const allowedOrganizationIds = (user.orgPermissions || []).map(
-    (perm) => perm.organizationId
-  );
-  const allowedCommunityIds = (user.communityPermissions || []).map(
-    (perm) => perm.communityId
-  );
-  const allowedSiteIds = (user.sitePermissions || []).map(
-    (perm) => perm.siteId
-  );
-
-  // Create query builder for site
-  let siteQuery = getManager().createQueryBuilder(Site, 'site');
-
-  // Join on organization to enable community Id check
-  // if either user community perms or qs community filter supplied
-  siteQuery =
-    allowedCommunityIds.length || communityIds.length
-      ? siteQuery.leftJoinAndSelect(
-          'site.organization',
-          'organization',
-          'organization.id = site."organizationId"'
-        )
-      : siteQuery;
-
-  // Add site id filter if user has site-specific access
-  siteQuery = allowedSiteIds.length
-    ? siteQuery.where('site.id in (:...siteIds)', { siteIds: allowedSiteIds })
-    : siteQuery;
-
-  // Add organization id filter if user has organization-specific access
-  siteQuery = allowedOrganizationIds.length
-    ? siteQuery.orWhere('site."organizationId" in (:...organizationIds)', {
-        organizationIds: allowedOrganizationIds,
-      })
-    : siteQuery;
-
-  // Add community id filter if user has community-specific access
-  siteQuery = allowedCommunityIds.length
-    ? siteQuery.orWhere('organization."communityId" in (:...communityIds)', {
-        communityIds: allowedCommunityIds,
-      })
-    : siteQuery;
-
-  // Get all allowed sites
-  // (apply these user-defined filters after retrieving from DB to ensure
-  // user cannot access sites they don't have permissions for)
-  let sites = await siteQuery.getMany();
-  return sites.filter(
-    (site) =>
-      (!siteIds.length || siteIds.includes(site.id)) &&
-      (!organizationIds.length ||
-        organizationIds.includes(site.organizationId)) &&
-      (!communityIds.length ||
-        communityIds.includes(site.organization.communityId))
+/**
+ * Return all sites the user has access to
+ * @param user
+ */
+export const getSites = async (user: User) => {
+  return (
+    await getManager().findByIds(Site, user.siteIds || []),
+    {
+      relations: ['organization'],
+    }
   );
 };

--- a/src/entity/FundingSpace.ts
+++ b/src/entity/FundingSpace.ts
@@ -18,7 +18,12 @@ import { Organization } from './Organization';
 import { FundingTimeSplit } from './FundingTimeSplit';
 
 @Entity()
-@Unique('UQ_Source_AgeGroup_Time', ['source', 'ageGroup', 'time'])
+@Unique('UQ_Source_AgeGroup_Time_Organization', [
+  'source',
+  'ageGroup',
+  'time',
+  'organization',
+])
 export class FundingSpace implements FundingSpaceInterface {
   @PrimaryGeneratedColumn()
   id: number;

--- a/src/entity/Organization.ts
+++ b/src/entity/Organization.ts
@@ -27,8 +27,8 @@ export class Organization implements OrganizationInterface {
   fundingSpaces?: Array<FundingSpace>;
 
   @ManyToOne(() => Community, { nullable: true })
-  community: Community;
+  community?: Community;
 
-  @Column()
-  communityId: number;
+  @Column({ nullable: true })
+  communityId?: number;
 }

--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -7,20 +7,24 @@ import {
   SitePermission,
   CommunityPermission,
 } from './Permission';
-import { Site } from './Site';
 
 @Entity()
 export class User implements UserInterface {
   @PrimaryGeneratedColumn()
   id: number;
-  @Column()
+
+  @Column({ unique: true })
   wingedKeysId: string;
+
   @Column()
   firstName: string;
+
   @Column()
   lastName: string;
+
   @Column({ nullable: true })
   middleName?: string;
+
   @Column({ nullable: true })
   suffix?: string;
 
@@ -33,7 +37,11 @@ export class User implements UserInterface {
   @OneToMany(() => CommunityPermission, (perm) => perm.user)
   communityPermissions?: Array<CommunityPermission>;
 
-  // not mapped
-  // convenience var: all sites the user has access to, via org + site permissions
-  sites?: Array<Site>;
+  // [virtual property] all sites the user has access to
+  // via site, org and community perms
+  siteIds?: Array<number>;
+
+  // [virtual property] add organizations the user has access to
+  // via org and community perms
+  organizationIds?: Array<number>;
 }

--- a/src/middleware/authenticate.ts
+++ b/src/middleware/authenticate.ts
@@ -1,8 +1,8 @@
 import jwt, { UnauthorizedError } from 'express-jwt';
 import jwks from 'jwks-rsa';
 import { Request, Response, NextFunction } from 'express';
-import { getManager } from 'typeorm';
-import { User } from '../entity';
+import { getManager, In } from 'typeorm';
+import { User, Organization, Site } from '../entity';
 import { InvalidSubClaimError } from './error/errors';
 import { passAsyncError } from './error/passAsyncError';
 
@@ -34,21 +34,64 @@ const decodeClaim = jwt({
 const addUser = passAsyncError(
   async (req: Request, _: Response, next: NextFunction) => {
     if (req.claims.sub) {
-      const user = await getManager().findOne(User, {
-        where: { wingedKeysId: req.claims.sub },
-        relations: [
-          'orgPermissions',
-          'sitePermissions',
-          'communityPermissions',
-        ],
-      });
-
+      const user = await getUser(req.claims.sub);
       if (!user) throw new InvalidSubClaimError();
       req.user = user;
       next();
     }
   }
 );
+
+/**
+ * Get user by wingedKeysId, and populate
+ * user.siteIds and user.organizationIds.
+ * @param wingedKeysId
+ */
+const getUser = async (wingedKeysId: string) => {
+  const user = await getManager().findOne(User, {
+    where: { wingedKeysId },
+    relations: ['orgPermissions', 'sitePermissions', 'communityPermissions'],
+  });
+
+  if (!user) return;
+
+  // Get all orgs associated with communities user has permissions for
+  const orgsFromCommunities = (user.communityPermissions || []).length
+    ? await getManager().find(Organization, {
+        where: {
+          communityId: In(
+            user.communityPermissions.map((perm) => perm.communityId)
+          ),
+        },
+      })
+    : [];
+
+  // Create list of distinct organization ids the user can access
+  const allOrgIds = Array.from(
+    new Set([
+      ...(user.orgPermissions || []).map((perm) => perm.organizationId),
+      ...orgsFromCommunities.map((org) => org.id),
+    ])
+  );
+
+  // Get all sites associated with all organizations user has permissions for
+  const sitesFromAllOrgs = await getManager().find(Site, {
+    where: { organizationId: In(allOrgIds) },
+  });
+
+  // Create list of distinct site ids the user can access
+  const allSiteIds = Array.from(
+    new Set([
+      ...(user.sitePermissions || []).map((perm) => perm.siteId),
+      ...sitesFromAllOrgs.map((site) => site.id),
+    ])
+  );
+
+  // Add values to the user object
+  user.organizationIds = allOrgIds;
+  user.siteIds = allSiteIds;
+  return user;
+};
 
 /**
  * Full authnetication middleware chains together decodeClaim and addUser,

--- a/src/migration/1598580605137-AlterFundingSpaceFixUnqiueConstraint.ts
+++ b/src/migration/1598580605137-AlterFundingSpaceFixUnqiueConstraint.ts
@@ -1,0 +1,30 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AlterFundingSpaceFixUnqiueConstraint1598580605137
+  implements MigrationInterface {
+  name = 'AlterFundingSpaceFixUnqiueConstraint1598580605137';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "funding_space" DROP CONSTRAINT "UQ_Source_AgeGroup_Time"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" ADD CONSTRAINT "UQ_fa30f106d866b8fb78e9d645d4b" UNIQUE ("wingedKeysId")`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "funding_space" ADD CONSTRAINT "UQ_Source_AgeGroup_Time_Organization" UNIQUE ("source", "ageGroup", "time", "organizationId")`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "funding_space" DROP CONSTRAINT "UQ_Source_AgeGroup_Time_Organization"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "user" DROP CONSTRAINT "UQ_fa30f106d866b8fb78e9d645d4b"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "funding_space" ADD CONSTRAINT "UQ_Source_AgeGroup_Time" UNIQUE ("source", "ageGroup", "time")`
+    );
+  }
+}

--- a/src/routes/fundingSpaces.ts
+++ b/src/routes/fundingSpaces.ts
@@ -1,0 +1,14 @@
+import express from 'express';
+import { passAsyncError } from '../middleware/error/passAsyncError';
+import * as controller from '../controllers/fundingSpaces';
+
+export const fundingSpacesRouter = express.Router();
+
+fundingSpacesRouter.get(
+  '/',
+  passAsyncError(async (req, res) => {
+    const fundingSpaces = await controller.getFundingSpaces(req.user);
+
+    res.send(fundingSpaces);
+  })
+);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,7 @@ import { columnMetadataRouter } from './columnMetadata';
 import { sitesRouter } from './sites';
 import { enrollmentsRouter } from './enrollments';
 import { familyRouter } from './families';
+import { fundingSpacesRouter } from './fundingSpaces';
 
 export const router = express.Router();
 
@@ -21,3 +22,4 @@ router.use('/children', authenticate, childrenRouter);
 router.use('/families', authenticate, familyRouter);
 router.use('/sites', authenticate, sitesRouter);
 router.use('/enrollments', authenticate, enrollmentsRouter);
+router.use('/funding-spaces', authenticate, fundingSpacesRouter);

--- a/src/routes/sites.ts
+++ b/src/routes/sites.ts
@@ -16,25 +16,7 @@ export const sitesRouter = express.Router();
 sitesRouter.get(
   '/',
   passAsyncError(async (req: Request, res: Response) => {
-    const siteIds = parseQueryString(req, 'id', {
-      post: parseInt,
-      forceArray: true,
-    }) as number[];
-    const organizationIds = parseQueryString(req, 'organizationId', {
-      post: parseInt,
-      forceArray: true,
-    }) as number[];
-    const communityIds = parseQueryString(req, 'communityId', {
-      post: parseInt,
-      forceArray: true,
-    }) as number[];
-
-    const sites = await controller.getSites(
-      req.user,
-      siteIds,
-      organizationIds,
-      communityIds
-    );
+    const sites = await controller.getSites(req.user);
 
     res.send(sites);
   })


### PR DESCRIPTION
adds service to retrieve all funding spaces a user has access to
also:
- updates user to have orgIds (all orgs the user can access, including those owned by communities user can access) and siteIds (all sites the user can access, including those owned by orgs they have access to, or orgs owned by communities they have access to) instead of sites property
- simplifies the site service, removing the siteId/organizationId/communityId filtering b/c we dont need it yet and why do i always build things we dont need 
- adds unique constraint on user.wingedKeysId
- correct unique constraint on funding space table to include organization id

