### PR TITLE
Child POST returns id for fetch pattern consistency

### DIFF
--- a/client/src/components/EditForms/ChildIdentifiers/Fields/DateOfBirth.tsx
+++ b/client/src/components/EditForms/ChildIdentifiers/Fields/DateOfBirth.tsx
@@ -10,6 +10,7 @@ export const DateOfBirthField: React.FC = () => {
   return (
     <FormField<Child, DateInputProps, Moment | null>
       getValue={(data) => data.at('birthdate')}
+      defaultValue={null}
       parseOnChangeEvent={(e) => (e as unknown) as Moment}
       inputComponent={DateInput}
       id="dateOfBirth-picker"

--- a/client/src/components/EditForms/ChildIdentifiers/__snapshots__/ChildIdentifiers.test.tsx.snap
+++ b/client/src/components/EditForms/ChildIdentifiers/__snapshots__/ChildIdentifiers.test.tsx.snap
@@ -179,7 +179,7 @@ exports[`EditRecord ChildIdentifiers matches snapshot 1`] = `
               max="12"
               min="1"
               type="number"
-              value="6"
+              value=""
             />
           </div>
           <div
@@ -198,7 +198,7 @@ exports[`EditRecord ChildIdentifiers matches snapshot 1`] = `
               max="31"
               min="1"
               type="number"
-              value="22"
+              value=""
             />
           </div>
           <div
@@ -217,7 +217,7 @@ exports[`EditRecord ChildIdentifiers matches snapshot 1`] = `
               max="2200"
               min="1000"
               type="number"
-              value="2008"
+              value=""
             />
           </div>
           <div
@@ -950,8 +950,8 @@ exports[`EditRecord ChildIdentifiers matches snapshot 1`] = `
                                   <tr>
                                     <td
                                       aria-disabled="false"
-                                      aria-label="Selected. Sunday, June 22, 2008"
-                                      class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3 CalendarDay__selected CalendarDay__selected_4"
+                                      aria-label="Sunday, June 22, 2008"
+                                      class="CalendarDay CalendarDay_1 CalendarDay__default CalendarDay__default_2 CalendarDay__firstDayOfWeek CalendarDay__firstDayOfWeek_3"
                                       role="button"
                                       style="width: 39px; height: 38px;"
                                       tabindex="-1"

--- a/client/src/containers/AddChild/ListSteps.tsx
+++ b/client/src/containers/AddChild/ListSteps.tsx
@@ -1,0 +1,102 @@
+import { StepProps, Button } from '@ctoec/component-library';
+import { EditFormProps } from '../../components/EditForms/types';
+import React from 'react';
+import {
+  ChildIdentifiersForm,
+  ChildInfoForm,
+  FamilyInfoForm,
+} from '../../components/EditForms';
+import { NewFamilyIncome } from './NewFamilyIncome';
+import { NewEnrollment } from './NewEnrollment';
+import { History } from 'history';
+
+export const listSteps: (_: any) => StepProps<EditFormProps>[] = (
+  history: History
+) => [
+  {
+    key: 'child-ident',
+    name: 'Child identifiers',
+    status: () => 'incomplete',
+    EditComponent: () => (
+      <Button
+        appearance="unstyled"
+        text={
+          <>
+            edit<span className="usa-sr-only"> child identifiers</span>
+          </>
+        }
+        onClick={() => history.replace({ hash: 'child-ident' })}
+      />
+    ),
+    Form: ChildIdentifiersForm,
+  },
+  {
+    key: 'child-info',
+    name: 'Child info',
+    status: () => 'incomplete',
+    EditComponent: () => (
+      <Button
+        appearance="unstyled"
+        text={
+          <>
+            edit<span className="usa-sr-only"> child info</span>
+          </>
+        }
+        onClick={() => history.replace({ hash: 'child-info' })}
+      />
+    ),
+    Form: ChildInfoForm,
+  },
+  {
+    key: 'family-address',
+    name: 'Family address',
+    status: () => 'incomplete',
+    EditComponent: () => (
+      <Button
+        appearance="unstyled"
+        text={
+          <>
+            edit<span className="usa-sr-only"> family address</span>
+          </>
+        }
+        onClick={() => history.replace({ hash: 'family-address' })}
+      />
+    ),
+    Form: FamilyInfoForm,
+  },
+  {
+    key: 'family-income',
+    name: 'Family income determination',
+    status: () => 'incomplete',
+    EditComponent: () => (
+      <Button
+        appearance="unstyled"
+        text={
+          <>
+            edit
+            <span className="usa-sr-only"> family income determination</span>
+          </>
+        }
+        onClick={() => history.replace({ hash: 'family-income' })}
+      />
+    ),
+    Form: NewFamilyIncome,
+  },
+  {
+    key: 'enrollment',
+    name: 'Enrollment and funding',
+    status: () => 'incomplete',
+    EditComponent: () => (
+      <Button
+        appearance="unstyled"
+        text={
+          <>
+            edit<span className="usa-sr-only"> enrollment and funding</span>
+          </>
+        }
+        onClick={() => history.replace({ hash: 'enrollment' })}
+      />
+    ),
+    Form: NewEnrollment,
+  },
+];

--- a/client/src/containers/AddChild/NewFamilyIncome.tsx
+++ b/client/src/containers/AddChild/NewFamilyIncome.tsx
@@ -6,6 +6,7 @@ import { Form, FormSubmitButton } from '@ctoec/component-library';
 import { IncomeDeterminationFieldSet } from '../../components/EditForms/FamilyIncome/Fields';
 import { EditFormProps } from '../../components/EditForms/types';
 import useIsMounted from '../../hooks/useIsMounted';
+import idx from 'idx';
 
 /**
  * Form component that allows the generation of a new income determination.
@@ -47,11 +48,14 @@ export const NewFamilyIncome: React.FC<EditFormProps> = ({
       .finally(() => (isMounted() ? setLoading(false) : null));
   };
 
+  const determination =
+    idx(child, (_) => _.family.incomeDeterminations[0]) ||
+    ({} as IncomeDetermination);
   return (
     <Form<IncomeDetermination>
       id="redetermine-income"
-      data={{} as IncomeDetermination}
-      onSubmit={(data) => onFormSubmit(data)}
+      data={determination}
+      onSubmit={onFormSubmit}
       className="usa-form"
     >
       <IncomeDeterminationFieldSet type="redetermine" />

--- a/client/src/containers/EditRecord/EditRecord.tsx
+++ b/client/src/containers/EditRecord/EditRecord.tsx
@@ -131,7 +131,6 @@ const EditRecord: React.FC = () => {
                   childName={rowData.firstName}
                   enrollment={activeEnrollment}
                   reportingPeriods={reportingPeriods}
-                  isOpen={withdrawModalOpen}
                   toggleOpen={toggleWithdrawModal}
                 />
               </Modal>

--- a/client/src/containers/EditRecord/WithdrawRecord/index.tsx
+++ b/client/src/containers/EditRecord/WithdrawRecord/index.tsx
@@ -21,14 +21,12 @@ type WithdrawProps = {
   childName: string;
   enrollment: Enrollment;
   reportingPeriods: ReportingPeriod[];
-  isOpen: boolean;
   toggleOpen: () => void;
 };
 export const WithdrawRecord: React.FC<WithdrawProps> = ({
   childName,
   enrollment,
   reportingPeriods,
-  isOpen,
   toggleOpen,
 }) => {
   const [isSaving, setIsSaving] = useState(false);

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -58,11 +58,6 @@ export const routes: RouteConfig[] = [
     exact: true,
   },
   {
-    path: '/create-record/:childId',
-    component: AddChild,
-    unauthorized: false,
-  },
-  {
     path: '/create-record',
     component: AddChild,
     unauthorized: false,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1869,9 +1869,9 @@
   integrity sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
 
 "@types/node@*":
-  version "14.10.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.1.tgz#cc323bad8e8a533d4822f45ce4e5326f36e42177"
-  integrity sha512-aYNbO+FZ/3KGeQCEkNhHFRIzBOUgc7QvcVNKXbfnhDkSfwUv91JsQQa10rDgKSTSLkXZ1UIyPe4FJJNVgw1xWQ==
+  version "14.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.10.2.tgz#9b47a2c8e4dabd4db73b57e750b24af689600514"
+  integrity sha512-IzMhbDYCpv26pC2wboJ4MMOa9GKtjplXfcAqrMeNJpUUwpM/2ATt2w1JPUXwS6spu856TvKZL2AOmeU2rAxskw==
 
 "@types/node@^12.0.0":
   version "12.12.54"

--- a/src/controllers/children.ts
+++ b/src/controllers/children.ts
@@ -3,7 +3,7 @@ import idx from 'idx';
 import { Moment } from 'moment';
 import { validate } from 'class-validator';
 import { ExitReason } from '../../client/src/shared/models';
-import { Child, ReportingPeriod, Enrollment, Funding } from '../entity';
+import { Child, ReportingPeriod, Enrollment, Funding, Family } from '../entity';
 import { ChangeEnrollment } from '../../client/src/shared/payloads';
 import { BadRequestError, NotFoundError } from '../middleware/error/errors';
 
@@ -59,6 +59,26 @@ const propertyDateSorter = <T>(
   if (aDate < bDate) return 1;
   if (bDate < aDate) return -1;
   return 0;
+};
+
+/**
+ * Creates a child from a POST request body.
+ * Also, creates a family if one does not exist.
+ * @param _child
+ */
+export const createChild = async (_child) => {
+  // TODO: make family optional on the child
+  // (to enable family lookup when adding new child)
+  // and stop creating it here
+  if (!_child.family) {
+    const organization = _child.organization;
+    const family = await getManager().save(
+      getManager().create(Family, { organization })
+    );
+    _child.family = family;
+  }
+
+  return getManager().save(getManager().create(Child, _child));
 };
 
 /**

--- a/src/controllers/enrollmentReports/map.ts
+++ b/src/controllers/enrollmentReports/map.ts
@@ -156,7 +156,7 @@ const mapChild = (
       source.receivingSpecialEducationServices || false,
     specialEducationServicesType,
     organization,
-    familyId: family.id,
+    family: family,
   });
 
   return getManager().save(child);

--- a/src/entity/Child.ts
+++ b/src/entity/Child.ts
@@ -118,19 +118,16 @@ export class Child implements ChildInterface {
   specialEducationServicesType?: SpecialEducationServicesType;
 
   @ValidateNested()
-  @ManyToOne((type) => Family, { nullable: false })
+  @ManyToOne(() => Family, { nullable: false })
   family: Family;
 
-  @Column()
-  familyId: number;
-
-  @ManyToOne((type) => Organization, { nullable: false })
+  @ManyToOne(() => Organization, { nullable: false })
   organization?: Organization;
 
   @ValidateNested({ each: true })
-  @OneToMany((type) => Enrollment, (enrollment) => enrollment.child)
+  @OneToMany(() => Enrollment, (enrollment) => enrollment.child)
   enrollments?: Array<Enrollment>;
 
-  @Column((type) => UpdateMetaData, { prefix: false })
+  @Column(() => UpdateMetaData, { prefix: false })
   updateMetaData?: UpdateMetaData;
 }

--- a/src/routes/children.ts
+++ b/src/routes/children.ts
@@ -1,4 +1,4 @@
-import express, { Response, Request } from 'express';
+import express from 'express';
 import { passAsyncError } from '../middleware/error/passAsyncError';
 import {
   NotFoundError,
@@ -7,7 +7,7 @@ import {
 } from '../middleware/error/errors';
 import * as controller from '../controllers/children';
 import { getManager } from 'typeorm';
-import { Child, Family } from '../entity';
+import { Child } from '../entity';
 
 export const childrenRouter = express.Router();
 
@@ -20,14 +20,8 @@ childrenRouter.post(
   '/',
   passAsyncError(async (req, res) => {
     try {
-      const organization = req.body.organization;
-      const family = await getManager().save(
-        getManager().create(Family, { organization })
-      );
-      const child = await getManager().save(
-        getManager().create(Child, { ...req.body, family })
-      );
-      res.send(child);
+      const child = await controller.createChild(req.body);
+      res.status(201).send({ id: child.id });
     } catch (err) {
       if (err instanceof ApiError) throw err;
       console.error('Error creating child: ', err);
@@ -44,7 +38,7 @@ childrenRouter.post(
  */
 childrenRouter.get(
   '/:childId',
-  passAsyncError(async (req: Request, res: Response) => {
+  passAsyncError(async (req, res) => {
     const childId = req.params['childId'];
     const child = await controller.getChildById(childId);
     if (!child) throw new NotFoundError();
@@ -58,7 +52,7 @@ childrenRouter.get(
  */
 childrenRouter.delete(
   '/:childId',
-  passAsyncError(async (req: Request, res: Response) => {
+  passAsyncError(async (req, res) => {
     try {
       const childId = req.params['childId'];
       await getManager().delete(Child, { id: childId });

--- a/src/routes/families.ts
+++ b/src/routes/families.ts
@@ -74,13 +74,14 @@ familyRouter.post(
       const famId = parseInt(req.params['familyId']);
       const family = await getManager().findOne(Family, { id: famId });
 
-      const determination = getManager().create(IncomeDetermination, {
-        ...req.body,
-        family,
-      });
+      const determination = await getManager().save(
+        getManager().create(IncomeDetermination, {
+          ...req.body,
+          family,
+        })
+      );
 
-      await getManager().save(determination);
-      res.sendStatus(200);
+      res.status(201).send({ id: determination.id });
     } catch (err) {
       if (err instanceof ApiError) throw err;
       console.log('Error creating new income determination: ', err);


### PR DESCRIPTION
For consistency with other API access patterns, make children POST return just 201 created with id, then have the API do another GET.
Remove childId from create-record path because it is not actually needed (page maintains child obj as state var, which has id once it exists). Having id in the path would enable the user to navigate back here if they lost connection etc during middle of create flow _BUT_ this won't work because organization is required, and is passed in via Link navigation to the page. So at some point, we want to decide what should happen if the user navigates to the add record page not from the right place (should they get an informative message? or just be redirected to the roster?) 

also:
- adds back incorrectly removed defaultValue null for birthdate (shouldn't default to today!)
- uses just created determination in new flow if user navigates back to that form section while still in new flow
- pulls steps definition out of the file for readability 