### PR TITLE
Handle jwt error for file upload

### DIFF
--- a/client/src/containers/Upload/Upload.tsx
+++ b/client/src/containers/Upload/Upload.tsx
@@ -6,6 +6,7 @@ import { ReactComponent as Arrow } from '@ctoec/component-library/dist/assets/im
 import { apiPost } from '../../utils/api';
 import { getErrorHeading, getErrorText } from '../../utils/error';
 import { getH1RefForTitle } from '../../utils/getH1RefForTitle';
+import { handleJWTError } from '../../utils/handleJWTError';
 
 const Upload: React.FC = () => {
   // USWDS File Input is managed by JS (not exclusive CSS)
@@ -36,10 +37,12 @@ const Upload: React.FC = () => {
         .then((value) => {
           history.push(`check-data/${value.id}`);
         })
-        .catch((err) => {
-          setError(err);
-          setFile(undefined);
-        });
+        .catch(
+          handleJWTError(history, (err) => {
+            setError(err);
+            setFile(undefined);
+          })
+        );
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [file]);

--- a/client/src/utils/handleJWTError.ts
+++ b/client/src/utils/handleJWTError.ts
@@ -1,0 +1,14 @@
+import { History } from 'history';
+
+export const handleJWTError = (
+  history: History,
+  errorHandler: (err: string) => any
+) => {
+  return (_err: string) => {
+    if (_err === 'jwt expired') {
+      history.push('/login');
+    } else {
+      errorHandler(_err);
+    }
+  };
+};


### PR DESCRIPTION
Closes #209 

This does the bare minimum to address the issue.  Some open questions:
- After someone logs in, should we redirect them to getting started (current behavior) or take them back to what they were trying to access?
- Should we somehow poll for log-in-ed-ness and automatically redirect people to the logged out screen after a certain period of time?
- How far do we want to go on winged keys branding to make this whole experience less confusing?