### PR TITLE
Correct alert placement for edit record

### DIFF
--- a/client/src/containers/AddChild/AddChild.tsx
+++ b/client/src/containers/AddChild/AddChild.tsx
@@ -120,11 +120,7 @@ const AddChild: React.FC = () => {
       .catch((err) => {
         console.log(err);
       });
-  }, [
-    accessToken,
-    childId,
-    refetchChild
-  ]);
+  }, [accessToken, childId, refetchChild]);
 
   // After child is updated, programmatically focus on the first input with an error
   useFocusFirstError([child]);

--- a/client/src/containers/EditRecord/EditRecord.tsx
+++ b/client/src/containers/EditRecord/EditRecord.tsx
@@ -103,7 +103,6 @@ const EditRecord: React.FC = () => {
             {rowData.firstName} {rowData.lastName}
           </h1>
         </div>
-        {alertElements}
         <div className="display-flex flex-col flex-align-center">
           {!!activeEnrollment && (
             <>
@@ -117,6 +116,7 @@ const EditRecord: React.FC = () => {
           <DeleteRecord child={rowData} />
         </div>
       </div>
+      {alertElements}
       <TabNav
         items={tabItems(commonFormProps)}
         activeId={activeTab}

--- a/client/src/containers/EditRecord/tabItems.tsx
+++ b/client/src/containers/EditRecord/tabItems.tsx
@@ -12,7 +12,10 @@ import {
   ChildIdentifiersForm,
   FamilyAddressForm,
 } from '../../components/Forms';
-import { SECTION_KEYS, formSections } from '../../components/Forms/formSections';
+import {
+  SECTION_KEYS,
+  formSections,
+} from '../../components/Forms/formSections';
 import { EditFormProps } from '../../components/Forms/types';
 
 const commonTextWithIconProps: Omit<TextWithIconProps, 'text'> = {
@@ -39,8 +42,8 @@ export const tabItems = (commonFormProps: EditFormProps) =>
       text: status(commonFormProps.child) ? (
         <TextWithIcon {...commonTextWithIconProps} text={name} />
       ) : (
-          name
-        ),
+        name
+      ),
       content: <EditForm {...commonFormProps} />,
     };
   });


### PR DESCRIPTION
Merged #446 a little too hastily-- the alerts were under the h1 but they were messing with layout of the links in edit child/accidentally subject to flexbox