### PR TITLE
Add batch edit item content for childIdent

### DIFF
--- a/client/src/components/Forms/ChildIdentifiers/ChildIdentifiers.test.tsx
+++ b/client/src/components/Forms/ChildIdentifiers/ChildIdentifiers.test.tsx
@@ -17,7 +17,7 @@ describe('EditRecord', () => {
   describe('ChildIdentifiers', () => {
     snapshotTestHelper(
       <ChildIdentifiersForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,
@@ -26,7 +26,7 @@ describe('EditRecord', () => {
 
     accessibilityTestHelper(
       <ChildIdentifiersForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,

--- a/client/src/components/Forms/ChildIdentifiers/Form.tsx
+++ b/client/src/components/Forms/ChildIdentifiers/Form.tsx
@@ -8,8 +8,8 @@ import {
   DateOfBirthField,
   BirthCertificateFormFieldSet,
 } from './Fields';
-import { Form, FormSubmitButton } from '@ctoec/component-library';
-import { EditFormProps } from '../types';
+import { Form, FormSubmitButton, Button } from '@ctoec/component-library';
+import { RecordFormProps } from '../types';
 import AuthenticationContext from '../../../contexts/AuthenticationContext/AuthenticationContext';
 import { Child } from '../../../shared/models';
 import { apiPut } from '../../../utils/api';
@@ -33,11 +33,15 @@ export const doesChildIdFormHaveErrors = (child?: Child) =>
   child ? !!getValidationStatusForFields(child, childIdentifiersFields) : true;
 
 export const ChildIdentifiersForm = ({
-  child: inputChild,
+  record: inputChild,
   afterDataSave,
   hideHeader = false,
   hideErrorsOnFirstLoad,
-}: EditFormProps) => {
+  batchEditProps = {
+    showField: () => true,
+    SkipButton: <></>,
+  },
+}: RecordFormProps) => {
   const { accessToken } = useContext(AuthenticationContext);
   const isMounted = useIsMounted();
   const [saving, setSaving] = useState(false);
@@ -62,6 +66,7 @@ export const ChildIdentifiersForm = ({
       .finally(() => (isMounted() ? setSaving(false) : null));
   };
 
+  const { showField, SkipButton } = batchEditProps;
   return (
     <Form<Child>
       className="ChildIdentifiersForm usa-form"
@@ -71,29 +76,44 @@ export const ChildIdentifiersForm = ({
       autoComplete="off"
     >
       {!hideHeader && <h2>Child's identifiers</h2>}
-      <div className="mobile-lg:grid-col-12">
-        <SasidField />
-      </div>
-      <div className="mobile-lg:grid-col-9">
-        <FirstNameField />
-      </div>
-      <div className="mobile-lg:grid-col-9">
-        <MiddleNameField />
-      </div>
-      <div className="display-flex flex-row flex-align-end grid-row grid-gap">
+      {showField('sasid', childIdentifiersFields, child) && (
+        <div className="mobile-lg:grid-col-12">
+          <SasidField />
+        </div>
+      )}
+      {showField('firstName', childIdentifiersFields, child) && (
         <div className="mobile-lg:grid-col-9">
-          <LastNameField />
+          <FirstNameField />
         </div>
-        <div className="mobile-lg:grid-col-3">
-          <SuffixField />
+      )}
+      {showField('middleName', childIdentifiersFields, child) && (
+        <div className="mobile-lg:grid-col-9">
+          <MiddleNameField />
         </div>
+      )}
+      <div className="display-flex flex-row flex-align-end grid-row grid-gap">
+        {showField('lastName', childIdentifiersFields, child) && (
+          <div className="mobile-lg:grid-col-9">
+            <LastNameField />
+          </div>
+        )}
+        {showField('suffix', childIdentifiersFields, child) && (
+          <div className="mobile-lg:grid-col-3">
+            <SuffixField />
+          </div>
+        )}
       </div>
-      <DateOfBirthField />
-      <BirthCertificateFormFieldSet />
+      {showField('birthdate', childIdentifiersFields, child) && (
+        <DateOfBirthField />
+      )}
+      {showField('birthCertificateId', childIdentifiersFields, child) && (
+        <BirthCertificateFormFieldSet />
+      )}
       <FormSubmitButton
         text={saving ? 'Saving...' : 'Save'}
         disabled={saving}
       />
+      {SkipButton}
     </Form>
   );
 };

--- a/client/src/components/Forms/ChildInfo/ChildInfo.test.tsx
+++ b/client/src/components/Forms/ChildInfo/ChildInfo.test.tsx
@@ -17,7 +17,7 @@ describe('EditRecord', () => {
   describe('ChildInfo', () => {
     snapshotTestHelper(
       <ChildInfoForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,
@@ -26,7 +26,7 @@ describe('EditRecord', () => {
 
     accessibilityTestHelper(
       <ChildInfoForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,

--- a/client/src/components/Forms/ChildInfo/Form.tsx
+++ b/client/src/components/Forms/ChildInfo/Form.tsx
@@ -7,8 +7,8 @@ import {
   DualLanguageLearner,
   Foster,
 } from './Fields';
-import { Form, FormSubmitButton } from '@ctoec/component-library';
-import { EditFormProps } from '../types';
+import { Form, FormSubmitButton, Button } from '@ctoec/component-library';
+import { RecordFormProps } from '../types';
 import AuthenticationContext from '../../../contexts/AuthenticationContext/AuthenticationContext';
 import { Child } from '../../../shared/models';
 import { apiPut } from '../../../utils/api';
@@ -34,11 +34,15 @@ export const doesChildInfoFormHaveErrors = (child?: Child) =>
   child ? !!getValidationStatusForFields(child, childInfoFields) : true;
 
 export const ChildInfoForm = ({
-  child: inputChild,
+  record: inputChild,
   afterDataSave,
   hideHeader = false,
   hideErrorsOnFirstLoad = false,
-}: EditFormProps) => {
+  batchEditProps = {
+    showField: () => true,
+    SkipButton: <></>,
+  },
+}: RecordFormProps) => {
   const { accessToken } = useContext(AuthenticationContext);
   const isMounted = useIsMounted();
   const [saving, setSaving] = useState(false);
@@ -63,6 +67,7 @@ export const ChildInfoForm = ({
       .finally(() => (isMounted() ? setSaving(false) : null));
   };
 
+  const { showField, SkipButton } = batchEditProps;
   return (
     <Form<Child>
       className="ChildInfoForm usa-form"
@@ -72,20 +77,38 @@ export const ChildInfoForm = ({
       autoComplete="off"
     >
       {!hideHeader && <h2>Child info</h2>}
-      <RaceField />
-      <EthnicityField />
-      <GenderField />
+      {showField(
+        [
+          'americanIndianOrAlaskaNative',
+          'asian',
+          'blackOrAfricanAmerican',
+          'nativeHawaiianOrPacificIslander',
+          'white',
+          'raceNotDisclosed',
+        ],
+        childInfoFields,
+        child
+      ) && <RaceField />}
+      {showField('hispanicOrLatinxEthnicity', childInfoFields, child) && (
+        <EthnicityField />
+      )}
+      {showField('gender', childInfoFields, child) && <GenderField />}
 
       <br />
       <h3 className="margin-bottom-0">Special circumstances</h3>
-      <DisabilityServices />
-      <DualLanguageLearner />
-      <Foster />
+      {showField('receivingDisabilityServices', childInfoFields, child) && (
+        <DisabilityServices />
+      )}
+      {showField('dualLanguageLearner', childInfoFields, child) && (
+        <DualLanguageLearner />
+      )}
+      {showField('foster', childInfoFields, child) && <Foster />}
 
       <FormSubmitButton
         text={saving ? 'Saving...' : 'Save'}
         disabled={saving}
       />
+      {SkipButton}
     </Form>
   );
 };

--- a/client/src/components/Forms/EnrollmentFunding/EnrollmentFunding.test.tsx
+++ b/client/src/components/Forms/EnrollmentFunding/EnrollmentFunding.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import moment from 'moment';
 import { RenderResult, fireEvent, wait } from '@testing-library/react';
-import { EnrollmentFundingForm } from './Form';
+import { EnrollmentFundingForm } from './Form/Form';
 import {
   snapshotTestHelper,
   accessibilityTestHelper,
@@ -68,7 +68,7 @@ describe('EditRecord', () => {
 
     snapshotTestHelper(
       <EnrollmentFundingForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,
@@ -76,7 +76,7 @@ describe('EditRecord', () => {
     );
     accessibilityTestHelper(
       <EnrollmentFundingForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,

--- a/client/src/components/Forms/EnrollmentFunding/Form/Form.tsx
+++ b/client/src/components/Forms/EnrollmentFunding/Form/Form.tsx
@@ -3,7 +3,7 @@ import { ChangeEnrollmentForm } from './ChangeEnrollmentForm';
 import { EditEnrollmentForm } from './EditEnrollmentForm';
 import { EditFundingForm } from './EditFundingForm';
 import { ChangeFundingForm } from './ChangeFundingForm';
-import { EditFormProps } from '../../types';
+import { RecordFormProps } from '../../types';
 import { useSites } from '../../../../hooks/useSites';
 import { getValidationStatusForFields } from '../../../../utils/getValidationStatus';
 import { Child } from '../../../../shared/models';
@@ -20,8 +20,8 @@ export const enrollmentFundingFields = {
   enrollments: [],
 };
 
-export const EnrollmentFundingForm: React.FC<EditFormProps> = ({
-  child,
+export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
+  record: child,
   afterDataSave,
 }) => {
   // Get site options for new enrollments

--- a/client/src/components/Forms/EnrollmentFunding/NewEnrollmentForm/NewEnrollment.tsx
+++ b/client/src/components/Forms/EnrollmentFunding/NewEnrollmentForm/NewEnrollment.tsx
@@ -7,7 +7,7 @@ import {
   NewFundingField,
 } from '../Fields';
 import { Form, FormSubmitButton } from '@ctoec/component-library';
-import { EditFormProps } from '../../types';
+import { RecordFormProps } from '../../types';
 import AuthenticationContext from '../../../../contexts/AuthenticationContext/AuthenticationContext';
 import { apiPost } from '../../../../utils/api';
 import { useSites } from '../../../../hooks/useSites';
@@ -18,10 +18,10 @@ import { getCurrentEnrollment } from '../../../../utils/models';
 // This is separate from the other enrollment forms because they're pretty complicated
 // Maybe we should try to reconcile though?
 export const NewEnrollment = ({
-  child: inputChild,
+  record: inputChild,
   afterDataSave,
   hideErrorsOnFirstLoad = false,
-}: EditFormProps) => {
+}: RecordFormProps) => {
   const { accessToken } = useContext(AuthenticationContext);
   const isMounted = useIsMounted();
   const [saving, setSaving] = useState(false);

--- a/client/src/components/Forms/FamilyAddress/FamilyInfo.test.tsx
+++ b/client/src/components/Forms/FamilyAddress/FamilyInfo.test.tsx
@@ -34,7 +34,7 @@ describe('EditRecord', () => {
   describe('FamilyInfo', () => {
     snapshotTestHelper(
       <FamilyAddressForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,
@@ -43,7 +43,7 @@ describe('EditRecord', () => {
 
     accessibilityTestHelper(
       <FamilyAddressForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />,

--- a/client/src/components/Forms/FamilyAddress/Form.tsx
+++ b/client/src/components/Forms/FamilyAddress/Form.tsx
@@ -4,7 +4,7 @@ import { Child, Family } from '../../../shared/models';
 import { AddressFieldset, HomelessnessField } from './Fields';
 import AuthenticationContext from '../../../contexts/AuthenticationContext/AuthenticationContext';
 import { apiPut } from '../../../utils/api';
-import { EditFormProps } from '../types';
+import { RecordFormProps } from '../types';
 import useIsMounted from '../../../hooks/useIsMounted';
 import { useValidationErrors } from '../../../hooks/useValidationErrors';
 import { getValidationStatusForFields } from '../../../utils/getValidationStatus';
@@ -28,8 +28,8 @@ export const doesFamilyAddressFormHaveErrors = (child?: Child) =>
  * with the Child object that the family form doesn't need
  * to know about.
  */
-export const FamilyAddressForm: React.FC<EditFormProps> = ({
-  child,
+export const FamilyAddressForm: React.FC<RecordFormProps> = ({
+  record: child,
   afterDataSave,
   hideHeader = false,
   hideErrorsOnFirstLoad = false,

--- a/client/src/components/Forms/FamilyIncome/FamilyIncome.test.tsx
+++ b/client/src/components/Forms/FamilyIncome/FamilyIncome.test.tsx
@@ -34,7 +34,7 @@ describe('EditForms', () => {
   describe('FamilyIncome', () => {
     snapshotTestHelper(
       <FamilyIncomeForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />
@@ -42,7 +42,7 @@ describe('EditForms', () => {
 
     accessibilityTestHelper(
       <FamilyIncomeForm
-        child={child}
+        record={child}
         afterDataSave={jest.fn()}
         setAlerts={jest.fn()}
       />

--- a/client/src/components/Forms/FamilyIncome/Form/EditDeterminationForm.tsx
+++ b/client/src/components/Forms/FamilyIncome/Form/EditDeterminationForm.tsx
@@ -10,7 +10,7 @@ import { IncomeDetermination } from '../../../../shared/models';
 import { apiPut } from '../../../../utils/api';
 import { IncomeDeterminationFieldSet } from '../Fields';
 import { IncomeDeterminationCard } from './DeterminationCard';
-import { EditFormProps } from '../../types';
+import { RecordFormProps } from '../../types';
 
 type EditDeterminationFormProps = {
   determination: IncomeDetermination;
@@ -18,7 +18,7 @@ type EditDeterminationFormProps = {
   isCurrent: boolean;
   isNew: boolean;
   afterDataSave: () => void;
-  setAlerts: EditFormProps['setAlerts'];
+  setAlerts: RecordFormProps['setAlerts'];
 };
 
 /**

--- a/client/src/components/Forms/FamilyIncome/Form/RedeterminationForm.tsx
+++ b/client/src/components/Forms/FamilyIncome/Form/RedeterminationForm.tsx
@@ -4,14 +4,14 @@ import { Button, Form, FormSubmitButton } from '@ctoec/component-library';
 import { IncomeDetermination } from '../../../../shared/models';
 import { apiPost } from '../../../../utils/api';
 import { IncomeDeterminationFieldSet } from '../Fields';
-import { EditFormProps } from '../../types';
+import { RecordFormProps } from '../../types';
 
 type RedeterminationFormProps = {
   familyId: number;
   setIsNew: () => void;
   hideForm: () => void;
   afterDataSave: () => void;
-  setAlerts: EditFormProps['setAlerts'];
+  setAlerts: RecordFormProps['setAlerts'];
 };
 
 /**

--- a/client/src/components/Forms/FamilyIncome/Form/index.tsx
+++ b/client/src/components/Forms/FamilyIncome/Form/index.tsx
@@ -3,7 +3,7 @@ import { Button, Card } from '@ctoec/component-library';
 import { propertyDateSorter } from '../../../../utils/dateSorter';
 import { EditDeterminationForm } from './EditDeterminationForm';
 import { RedeterminationForm } from './RedeterminationForm';
-import { EditFormProps } from '../../types';
+import { RecordFormProps } from '../../types';
 import { getValidationStatusForFields } from '../../../../utils/getValidationStatus';
 import { Child } from '../../../../shared/models';
 
@@ -16,8 +16,8 @@ export const doesFamilyIncomeFormHaveErrors = (child?: Child) =>
       )
     : true;
 
-export const FamilyIncomeForm: React.FC<EditFormProps> = (props) => {
-  const { child, afterDataSave } = props;
+export const FamilyIncomeForm: React.FC<RecordFormProps> = (props) => {
+  const { record: child, afterDataSave } = props;
   const [showRedeterminationForm, setShowRedeterminationForm] = useState(false);
   const [currentIsNew, setCurrentIsNew] = useState(false);
 

--- a/client/src/components/Forms/FamilyIncome/NewFamilyIncome/NewFamilyIncome.tsx
+++ b/client/src/components/Forms/FamilyIncome/NewFamilyIncome/NewFamilyIncome.tsx
@@ -4,7 +4,7 @@ import { Child, IncomeDetermination } from '../../../../shared/models';
 import { apiPost } from '../../../../utils/api';
 import { Form, FormSubmitButton } from '@ctoec/component-library';
 import { IncomeDeterminationFieldSet } from '../Fields';
-import { EditFormProps } from '../../types';
+import { RecordFormProps } from '../../types';
 import useIsMounted from '../../../../hooks/useIsMounted';
 import idx from 'idx';
 import { useValidationErrors } from '../../../../hooks/useValidationErrors';
@@ -14,8 +14,8 @@ import { useValidationErrors } from '../../../../hooks/useValidationErrors';
  * Form is accessed via a button revealed by clicking "Redetermine income,"
  * and values default to 0 but are overwritten by user input.
  */
-export const NewFamilyIncome: React.FC<EditFormProps> = ({
-  child: inputChild,
+export const NewFamilyIncome: React.FC<RecordFormProps> = ({
+  record: inputChild,
   afterDataSave,
   setAlerts,
   hideErrorsOnFirstLoad = false,

--- a/client/src/components/Forms/formSections.tsx
+++ b/client/src/components/Forms/formSections.tsx
@@ -20,33 +20,33 @@ export const SECTION_KEYS = {
 export type FormSectionInfo = {
   key: string;
   name: string;
-  status: (child?: Child) => boolean;
+  hasErrors: (child?: Child) => boolean;
 };
 
 export const formSections: FormSectionInfo[] = [
   {
     key: SECTION_KEYS.IDENT,
     name: 'Child identifiers',
-    status: doesChildIdFormHaveErrors,
+    hasErrors: doesChildIdFormHaveErrors,
   },
   {
     key: SECTION_KEYS.DEMO,
     name: 'Child info',
-    status: doesChildInfoFormHaveErrors,
+    hasErrors: doesChildInfoFormHaveErrors,
   },
   {
     key: SECTION_KEYS.FAMILY,
     name: 'Family address',
-    status: doesFamilyAddressFormHaveErrors,
+    hasErrors: doesFamilyAddressFormHaveErrors,
   },
   {
     key: SECTION_KEYS.INCOME,
     name: 'Family income',
-    status: doesFamilyIncomeFormHaveErrors,
+    hasErrors: doesFamilyIncomeFormHaveErrors,
   },
   {
     key: SECTION_KEYS.ENROLLMENT,
     name: 'Enrollment and funding',
-    status: doesEnrollmentFormHaveErrors,
+    hasErrors: doesEnrollmentFormHaveErrors,
   },
 ];

--- a/client/src/components/Forms/index.tsx
+++ b/client/src/components/Forms/index.tsx
@@ -1,4 +1,4 @@
-export * from './EnrollmentFunding/Form';
+export * from './EnrollmentFunding/Form/Form';
 export * from './FamilyAddress/Form';
 export * from './ChildInfo/Form';
 export * from './ChildIdentifiers/Form';

--- a/client/src/components/Forms/types.ts
+++ b/client/src/components/Forms/types.ts
@@ -1,13 +1,16 @@
-import { Child, ReportingPeriod } from '../../shared/models';
+import { Child } from '../../shared/models';
 import { Dispatch, SetStateAction } from 'react';
 import { AlertProps } from '@ctoec/component-library';
 import { HideErrors } from '../../hooks/useValidationErrors';
 
-export type EditFormProps = {
-  child: Child | undefined;
+export type RecordFormProps = {
+  record: Child | undefined;
   afterDataSave: () => void;
   setAlerts: Dispatch<SetStateAction<AlertProps[]>>;
-  hideHeader?: boolean;
+  hideHeader?: boolean; // Header needs to be hidden in step list because it includes a header
   hideErrorsOnFirstLoad?: HideErrors;
-  // Header needs to be hidden in step list because the step list includes a header
+  batchEditProps?: {
+    showField: (_: string | string[], __: string[], record: Child) => boolean;
+    SkipButton: JSX.Element;
+  };
 };

--- a/client/src/containers/AddRecord/AddRecord.tsx
+++ b/client/src/containers/AddRecord/AddRecord.tsx
@@ -7,7 +7,7 @@ import AuthenticationContext from '../../contexts/AuthenticationContext/Authenti
 import { useLocation, useHistory, useParams } from 'react-router-dom';
 import { useAlerts } from '../../hooks/useAlerts';
 import { getH1RefForTitle } from '../../utils/getH1RefForTitle';
-import { EditFormProps } from '../../components/Forms/types';
+import { RecordFormProps } from '../../components/Forms/types';
 import { useFocusFirstError } from '../../hooks/useFocusFirstError';
 import { listSteps } from './listSteps';
 
@@ -17,16 +17,17 @@ type LocationType = Location & {
   };
 };
 
-const AddChild: React.FC = () => {
+const AddRecord: React.FC = () => {
   const h1Ref = getH1RefForTitle();
   const { accessToken } = useContext(AuthenticationContext);
   const { state: locationState, hash } = useLocation() as LocationType;
   const { childId } = useParams() as { childId: string };
   const activeStep = hash.slice(1);
   const history = useHistory();
+
+  // Keep track of steps that have been visited at least once
   const steps = listSteps(history);
   const indexOfCurrentStep = steps.findIndex((s) => s.key === activeStep) || 0;
-  // Keep track of steps that have been visited at least once
   const [stepsVisited, updateStepsVisited] = useState<
     { key: string; visited: boolean; active: boolean }[]
   >(
@@ -45,7 +46,6 @@ const AddChild: React.FC = () => {
   }, [activeStep, history, steps]);
 
   const [child, updateChild] = useState<Child>();
-  // TODO how do we choose correct org / site for creating new data
   const organization = locationState?.organization || child?.organization;
   const [refetchChild, setRefetchChild] = useState<number>(0);
   const triggerRefetchChild = () => setRefetchChild((r) => r + 1);
@@ -111,8 +111,10 @@ const AddChild: React.FC = () => {
       .then((updatedChild) => {
         updateChild(updatedChild);
         const currentStepStatus = steps[indexOfCurrentStep].status({
-          child: updatedChild,
-        } as EditFormProps);
+          record: updatedChild,
+        } as RecordFormProps);
+        // only allow the user to progress to next step if they have
+        // added all necessary information to current step
         if (currentStepStatus === 'complete') {
           moveToNextStep();
         }
@@ -128,7 +130,7 @@ const AddChild: React.FC = () => {
   const { alertElements, setAlerts } = useAlerts();
 
   const commonFormProps = {
-    child,
+    record: child,
     afterDataSave: triggerRefetchChild,
     setAlerts,
     hideHeader: true,
@@ -154,4 +156,4 @@ const AddChild: React.FC = () => {
     </div>
   );
 };
-export default AddChild;
+export default AddRecord;

--- a/client/src/containers/AddRecord/listSteps.tsx
+++ b/client/src/containers/AddRecord/listSteps.tsx
@@ -1,7 +1,7 @@
 import { StepProps, Button } from '@ctoec/component-library';
 import React from 'react';
 import { History } from 'history';
-import { EditFormProps } from '../../components/Forms/types';
+import { RecordFormProps } from '../../components/Forms/types';
 import {
   ChildIdentifiersForm,
   ChildInfoForm,
@@ -22,16 +22,15 @@ export const newForms = [
   { key: SECTION_KEYS.ENROLLMENT, form: NewEnrollment },
 ];
 
-export const listSteps: (_: any) => StepProps<EditFormProps>[] = (
+export const listSteps: (_: any) => StepProps<RecordFormProps>[] = (
   history: History
 ) =>
-  formSections.map(({ key, name, status }) => {
+  formSections.map(({ key, name, hasErrors }) => {
     const Form = newForms.find((s) => s.key === key)?.form || (() => <></>);
     return {
       key,
       name,
-      status: ({ child }) =>
-        child && status(child) ? 'incomplete' : 'complete',
+      status: ({ record }) => (hasErrors(record) ? 'incomplete' : 'complete'),
       EditComponent: () => (
         <Button
           appearance="unstyled"

--- a/client/src/containers/BatchEdit/BatchEdit.tsx
+++ b/client/src/containers/BatchEdit/BatchEdit.tsx
@@ -15,6 +15,7 @@ import { hasValidationError } from '../../utils/hasValidationError';
 import pluralize from 'pluralize';
 import { nameFormatter } from '../../utils/formatters';
 import { Link } from 'react-router-dom';
+import { BatchEditItemContent } from './BatchEditItemContent';
 
 const BatchEdit: React.FC = () => {
   const h1Ref = getH1RefForTitle();
@@ -65,7 +66,7 @@ const BatchEdit: React.FC = () => {
         <>Loading</>
       ) : (
         <>
-          <p className="display-flex font-body-lg height-5 line-height-body-6 margin-y-0">
+          <div className="display-flex font-body-lg height-5 line-height-body-6 margin-y-0">
             {missingInformationRecordsCount ? (
               <>
                 <div className="text-white text-bold text-center bg-primary width-5 radius-pill margin-right-1">
@@ -82,7 +83,7 @@ const BatchEdit: React.FC = () => {
                 enrollments are complete
               </>
             )}
-          </p>
+          </div>
           <SideNav
             externalActiveItemIndex={activeRecordIdx}
             items={allRecords.map((record) => ({
@@ -95,7 +96,12 @@ const BatchEdit: React.FC = () => {
                 </span>
               ),
               description: 'Placeholder',
-              content: <div>PLACEHOLDER </div>,
+              content: (
+                <BatchEditItemContent
+                  record={record}
+                  moveNextRecord={moveNextRecord}
+                />
+              ),
             }))}
             noActiveItemContent={
               <div className="margin-x-4 margin-top-4 display-flex flex-column flex-align-center">

--- a/client/src/containers/BatchEdit/BatchEditItemContent.tsx
+++ b/client/src/containers/BatchEdit/BatchEditItemContent.tsx
@@ -1,0 +1,141 @@
+import React, { useState, useEffect, useContext } from 'react';
+import { Child } from '../../shared/models';
+import { StepProps, StepList, Button } from '@ctoec/component-library';
+import { RecordFormProps } from '../../components/Forms/types';
+import { listSteps } from './listSteps';
+import { nameFormatter } from '../../utils/formatters';
+import { useAlerts } from '../../hooks/useAlerts';
+import { hasValidationErrorForField } from '../../utils/hasValidationError';
+import { apiGet } from '../../utils/api';
+import AuthenticationContext from '../../contexts/AuthenticationContext/AuthenticationContext';
+import DataCacheContext from '../../contexts/DataCacheContext/DataCacheContext';
+import { Link } from 'react-router-dom';
+
+type BatchEditItemContentProps = {
+  record: Child;
+  moveNextRecord: () => void;
+};
+
+export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
+  record,
+  moveNextRecord,
+}) => {
+  const { children } = useContext(DataCacheContext);
+  const { setAlerts } = useAlerts();
+
+  const [steps, setSteps] = useState<StepProps<RecordFormProps>[]>([]);
+  const [activeStepKey, setActiveStep] = useState('');
+  useEffect(() => {
+    if (record) {
+      const _steps = listSteps(record, setActiveStep);
+      setSteps(_steps);
+      setActiveStep(_steps[0].key);
+    }
+  }, [!!record]);
+
+  const { accessToken } = useContext(AuthenticationContext);
+  const [refetchChild, setRefetchChild] = useState(0);
+  const triggerRefetchChild = () => setRefetchChild((r) => r + 1);
+
+  const moveNextStep = () => {
+    if (!activeStepKey) return;
+
+    const activeStepIdx = steps.findIndex((step) => step.key === activeStepKey);
+    if (activeStepIdx === steps.length - 1) {
+      moveNextRecord();
+    } else {
+      setActiveStep(steps[activeStepIdx + 1].key);
+    }
+  };
+
+  useEffect(() => {
+    if (!activeStepKey) return;
+
+    apiGet(`/children/${record.id}`, { accessToken })
+      .then((updatedChild) => {
+        children.addOrUpdateRecord(updatedChild);
+        const currentStepStatus = steps
+          .find((step) => step.key === activeStepKey)
+          ?.status(updatedChild);
+        if (currentStepStatus === 'complete') {
+          moveNextStep();
+        }
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+    // only trigger refetch on explicit refetch
+    // not when record prop changes (user clicks on tab nav)
+    //es-lint-disable-next-line
+  }, [accessToken, refetchChild]);
+
+  const showFieldInBatchEditForm = (
+    fields: string | string[],
+    allFormFields: string[],
+    record: Child
+  ) => {
+    if (Array.isArray(fields)) {
+      for (let i = 0; i++; i < fields.length) {
+        if (
+          allFormFields.includes(fields[i]) &&
+          hasValidationErrorForField(record, fields[i])
+        )
+          return true;
+      }
+      return false;
+    }
+
+    return (
+      allFormFields.includes(fields) &&
+      hasValidationErrorForField(record, fields)
+    );
+  };
+
+  const props: RecordFormProps = {
+    record,
+    afterDataSave: triggerRefetchChild,
+    setAlerts,
+    hideHeader: true,
+    hideErrorsOnFirstLoad: () => false,
+    batchEditProps: {
+      showField: showFieldInBatchEditForm,
+      SkipButton: (
+        <Button text="Skip" onClick={moveNextStep} appearance="outline" />
+      ),
+    },
+  };
+
+  if (!steps.length || !activeStepKey || !record) {
+    return <> </>;
+  }
+
+  return (
+    <>
+      <div className="padding-x-2 padding-bottom-3">
+        <div className="display-flex flex-row flex-justify flex-align-end">
+          <h2>{nameFormatter(record)}</h2>
+          <div className="text-baseline">
+            Date of birth: {record.birthdate?.format('MM/DD/YYYY')}
+          </div>
+        </div>
+        <div className="margin-top-1">
+          <Link to={`/edit-record/${record.id}`} />
+        </div>
+      </div>
+      <div className="padding-top-1 border-top-1px border-base-light">
+        {steps.length ? (
+          <StepList<RecordFormProps>
+            key={record.id}
+            steps={steps}
+            props={props}
+            activeStep={activeStepKey}
+          />
+        ) : (
+          <div className="margin-y-2 display-flex flex-center">
+            All complete!
+          </div>
+        )}
+      </div>
+    </>
+  );
+};

--- a/client/src/containers/BatchEdit/listSteps.tsx
+++ b/client/src/containers/BatchEdit/listSteps.tsx
@@ -1,0 +1,59 @@
+import { StepProps, Button } from '@ctoec/component-library';
+import React from 'react';
+import { History } from 'history';
+import { RecordFormProps } from '../../components/Forms/types';
+import {
+  ChildIdentifiersForm,
+  ChildInfoForm,
+  FamilyAddressForm,
+} from '../../components/Forms';
+import { NewEnrollment } from '../../components/Forms/EnrollmentFunding/NewEnrollmentForm/NewEnrollment';
+import { NewFamilyIncome } from '../../components/Forms/FamilyIncome/NewFamilyIncome/NewFamilyIncome';
+import {
+  SECTION_KEYS,
+  formSections,
+} from '../../components/Forms/formSections';
+import { Child } from '../../shared/models';
+
+export const newForms = [
+  { key: SECTION_KEYS.IDENT, form: ChildIdentifiersForm },
+  // { key: SECTION_KEYS.DEMO, form: ChildInfoForm },
+  // { key: SECTION_KEYS.FAMILY, form: FamilyAddressForm },
+  // { key: SECTION_KEYS.INCOME, form: NewFamilyIncome },
+  // { key: SECTION_KEYS.ENROLLMENT, form: NewEnrollment },
+];
+
+export const listSteps = (
+  record: Child,
+  setActiveStep: (stepKey: string) => void
+) =>
+  formSections
+    .map(({ key, name, hasErrors }) => {
+      const Form = newForms.find((s) => s.key === key)?.form || (() => <></>);
+      const hasMissingInfo = hasErrors(record);
+      if (hasMissingInfo) {
+        return {
+          key,
+          name,
+          // TODO: WHY THE F is this "props" object actually the child record???????
+          status: (props) => {
+            return hasErrors((props as any) as Child)
+              ? 'incomplete'
+              : 'complete';
+          },
+          Form,
+          EditComponent: () => (
+            <Button
+              appearance="unstyled"
+              text={
+                <>
+                  edit<span className="usa-sr-only"> {` ${name}`}</span>
+                </>
+              }
+              onClick={() => setActiveStep(key)}
+            />
+          ),
+        } as StepProps<RecordFormProps>;
+      }
+    })
+    .filter((step) => !!step) as StepProps<RecordFormProps>[];

--- a/client/src/containers/EditRecord/tabItems.tsx
+++ b/client/src/containers/EditRecord/tabItems.tsx
@@ -15,7 +15,7 @@ import {
   SECTION_KEYS,
   formSections,
 } from '../../components/Forms/formSections';
-import { EditFormProps } from '../../components/Forms/types';
+import { RecordFormProps } from '../../components/Forms/types';
 
 const commonTextWithIconProps: Omit<TextWithIconProps, 'text'> = {
   Icon: Info,
@@ -31,13 +31,13 @@ export const editForms = [
   { key: SECTION_KEYS.ENROLLMENT, form: EnrollmentFundingForm },
 ];
 
-export const tabItems = (commonFormProps: EditFormProps) =>
-  formSections.map(({ key, name, status }) => {
+export const tabItems = (commonFormProps: RecordFormProps) =>
+  formSections.map(({ key, name, hasErrors }) => {
     const EditForm =
       editForms.find((e) => e.key === key)?.form || (() => <></>);
     return {
       id: key,
-      text: status(commonFormProps.child) ? (
+      text: hasErrors(commonFormProps.record) ? (
         <TextWithIcon {...commonTextWithIconProps} text={name} />
       ) : (
         name

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -7,7 +7,7 @@ import GettingStarted from './containers/GettingStarted/GettingStarted';
 import EditRecord from './containers/EditRecord/EditRecord';
 import DataRequirements from './containers/DataRequirements/DataRequirements';
 import SubmitSuccess from './containers/SubmitSuccess/SubmitSuccess';
-import AddChild from './containers/AddChild/AddChild';
+import AddRecord from './containers/AddRecord/AddRecord';
 import FundingSourceTimes from './containers/FundingSourceTimes/FundingSourceTimes';
 import Roster from './containers/Roster/Roster';
 import BatchEdit from './containers/BatchEdit/BatchEdit';
@@ -65,7 +65,7 @@ export const routes: RouteConfig[] = [
   },
   {
     path: '/create-record/:childId?',
-    component: AddChild,
+    component: AddRecord,
     unauthorized: false,
   },
   {

--- a/client/src/utils/hasValidationError.ts
+++ b/client/src/utils/hasValidationError.ts
@@ -1,5 +1,15 @@
-import { Child } from '../shared/models';
+import { Child, ObjectWithValidationErrors } from '../shared/models';
 
 export const hasValidationError = (record?: Child) => {
   return record && record.validationErrors && record.validationErrors.length;
+};
+
+export const hasValidationErrorForField = (
+  entity: ObjectWithValidationErrors,
+  field: string
+) => {
+  return (
+    !!entity.validationErrors &&
+    entity.validationErrors.some((err) => err.property === field)
+  );
 };


### PR DESCRIPTION
closes #475 closes #476 

I realized that we really should be using the same forms for all this stuff, so i'm throwing this up and then going to work on getting edit enrollment, new enrollment, and change enrollment to all leverage the same base form. That way, if we update form stuff, we don't have to do it in multiple places (i.e. noticed care model was missing from one of the many enrollment forms). 

Idea is we can use the new additional `batchEditProps` to correctly display the form in batch edit vs normal add/edit mode

some things are renamed for clarity to my brain while working thru this

tests not yet reconciled, but wanted to get this in front of brains/eyes