### PR TITLE
Correct table spacing

### DIFF
--- a/client/src/containers/FundingSourceTimes/FundingSourceTimes.tsx
+++ b/client/src/containers/FundingSourceTimes/FundingSourceTimes.tsx
@@ -1,21 +1,63 @@
 import React from 'react';
 import { Table, Column } from '@ctoec/component-library';
 import { BackButton } from '../../components/BackButton';
-import { FundingSourceTime } from '../../shared/models';
+import {
+  FundingSource,
+  FundingSourceTime,
+  FundingSpace,
+  FundingTime,
+} from '../../shared/models';
 import { FUNDING_SOURCE_TIMES } from '../../shared/constants';
 import { getH1RefForTitle } from '../../utils/getH1RefForTitle';
 
 const FundingSourceTimes: React.FC = () => {
   const h1Ref = getH1RefForTitle();
 
-  const columns: Column<FundingSourceTime>[] = [
+  /**
+   * Structure to hold simplified information needed to show Funding
+   * Spaces across columns with proper formatting.
+   */
+  type SpaceToFunding = {
+    space: FundingTime;
+    type: string;
+    sources: FundingSource[];
+    format: string;
+    numSpacesInType: number;
+    showSpace: boolean;
+  };
+
+  // Only want to display the FundingSpace row header once for each
+  // applicable block of contract spaces
+  let setSpaceHeader: boolean;
+  const spaces: SpaceToFunding[] = [];
+
+  // Need to 'invert' the array of funding_source_times because we
+  // want _contract spaces_ to be what defines a row so that the
+  // text between spaces and their formats will always match
+  FUNDING_SOURCE_TIMES.map((fst) => {
+    setSpaceHeader = false;
+    fst.fundingTimes.map((time) => {
+      const spaceFromFST: SpaceToFunding = {
+        space: time.value,
+        type: fst.displayName,
+        sources: fst.fundingSources,
+        format: time.formats.map((format) => '"' + format + '"').join(' or '),
+        numSpacesInType: fst.fundingTimes.length,
+        showSpace: !setSpaceHeader,
+      };
+      spaces.push(spaceFromFST);
+      setSpaceHeader = true;
+    });
+  });
+
+  const columns: Column<SpaceToFunding>[] = [
     {
       name: 'Funding Type',
       cell: ({ row }) =>
-        row ? (
-          <th scope="row">
-            <div className="text-bold">{row.displayName}</div>
-            <div>({row.fundingSources.join(' or ')})</div>
+        row && row.showSpace ? (
+          <th scope="row" rowSpan={row.numSpacesInType}>
+            <div className="text-bold">{row.type}</div>
+            <div>({row.sources.join(' or ')})</div>
           </th>
         ) : (
           <></>
@@ -26,13 +68,7 @@ const FundingSourceTimes: React.FC = () => {
       cell: ({ row }) =>
         row ? (
           <td>
-            {row.fundingTimes.map((fundingTime) => {
-              return (
-                <div className="margin-top-3 margin-bottom-3">
-                  {fundingTime.value}
-                </div>
-              );
-            })}
+            <div className="margin-top-3 margin-bottom-3">{row.space}</div>
           </td>
         ) : (
           <></>
@@ -40,22 +76,7 @@ const FundingSourceTimes: React.FC = () => {
     },
     {
       name: 'Accepted formats',
-      cell: ({ row }) =>
-        row ? (
-          <td>
-            {row.fundingTimes.map((fundingTime) => {
-              return (
-                <div className="margin-top-3 margin-bottom-3">
-                  {fundingTime.formats
-                    .map((format) => '"' + format + '"')
-                    .join(' or ')}
-                </div>
-              );
-            })}
-          </td>
-        ) : (
-          <></>
-        ),
+      cell: ({ row }) => (row ? <td>{row.format}</td> : <></>),
     },
   ];
 
@@ -70,8 +91,8 @@ const FundingSourceTimes: React.FC = () => {
       <div className="margin-top-4">
         <Table
           id="data-requirements-table"
-          data={FUNDING_SOURCE_TIMES}
-          rowKey={(row) => (row ? row.displayName : '')}
+          data={spaces}
+          rowKey={(row) => (row ? row.format : '')}
           columns={columns}
           defaultSortColumn={0}
         />

--- a/client/src/containers/FundingSourceTimes/FundingSourceTimes.tsx
+++ b/client/src/containers/FundingSourceTimes/FundingSourceTimes.tsx
@@ -12,47 +12,49 @@ const FundingSourceTimes: React.FC = () => {
    * Structure to hold simplified information needed to show Funding
    * Spaces across columns with proper formatting.
    */
-  type SpaceToFunding = {
-    space: FundingTime;
-    type: string;
-    sources: FundingSource[];
-    format: string;
-    numSpacesInType: number;
-    showSpace: boolean;
+  type ContractSpaceDetails = {
+    contractSpace: FundingTime;
+    fundingType: string;
+    fundingSources: FundingSource[];
+    acceptedInputFormats: string;
+    numContractSpacesInFundingType: number;
+    displaySpace: boolean;
   };
 
   // Only want to display the FundingSpace row header once for each
   // applicable block of contract spaces
-  let setSpaceHeader: boolean;
-  const spaces: SpaceToFunding[] = [];
+  let shouldShowFundingType: boolean;
+  const contractSpaces: ContractSpaceDetails[] = [];
 
   // Need to 'invert' the array of funding_source_times because we
   // want _contract spaces_ to be what defines a row so that the
   // text between spaces and their formats will always match
   FUNDING_SOURCE_TIMES.map((fst) => {
-    setSpaceHeader = false;
+    shouldShowFundingType = false;
     fst.fundingTimes.map((time) => {
-      const spaceFromFST: SpaceToFunding = {
-        space: time.value,
-        type: fst.displayName,
-        sources: fst.fundingSources,
-        format: time.formats.map((format) => '"' + format + '"').join(' or '),
-        numSpacesInType: fst.fundingTimes.length,
-        showSpace: !setSpaceHeader,
+      const spaceFromFST: ContractSpaceDetails = {
+        contractSpace: time.value,
+        fundingType: fst.displayName,
+        fundingSources: fst.fundingSources,
+        acceptedInputFormats: time.formats
+          .map((format) => '"' + format + '"')
+          .join(' or '),
+        numContractSpacesInFundingType: fst.fundingTimes.length,
+        displaySpace: !shouldShowFundingType,
       };
-      spaces.push(spaceFromFST);
-      setSpaceHeader = true;
+      contractSpaces.push(spaceFromFST);
+      shouldShowFundingType = true;
     });
   });
 
-  const columns: Column<SpaceToFunding>[] = [
+  const columns: Column<ContractSpaceDetails>[] = [
     {
       name: 'Funding Type',
       cell: ({ row }) =>
-        row && row.showSpace ? (
-          <th scope="row" rowSpan={row.numSpacesInType}>
-            <div className="text-bold">{row.type}</div>
-            <div>({row.sources.join(' or ')})</div>
+        row && row.displaySpace ? (
+          <th scope="row" rowSpan={row.numContractSpacesInFundingType}>
+            <div className="text-bold">{row.fundingType}</div>
+            <div>({row.fundingSources.join(' or ')})</div>
           </th>
         ) : (
           <></>
@@ -63,7 +65,9 @@ const FundingSourceTimes: React.FC = () => {
       cell: ({ row }) =>
         row ? (
           <td>
-            <div className="margin-top-3 margin-bottom-3">{row.space}</div>
+            <div className="margin-top-3 margin-bottom-3">
+              {row.contractSpace}
+            </div>
           </td>
         ) : (
           <></>
@@ -71,7 +75,7 @@ const FundingSourceTimes: React.FC = () => {
     },
     {
       name: 'Accepted formats',
-      cell: ({ row }) => (row ? <td>{row.format}</td> : <></>),
+      cell: ({ row }) => (row ? <td>{row.acceptedInputFormats}</td> : <></>),
     },
   ];
 
@@ -86,8 +90,8 @@ const FundingSourceTimes: React.FC = () => {
       <div className="margin-top-4">
         <Table
           id="data-requirements-table"
-          data={spaces}
-          rowKey={(row) => (row ? row.format : '')}
+          data={contractSpaces}
+          rowKey={(row) => (row ? row.acceptedInputFormats : '')}
           columns={columns}
           defaultSortColumn={0}
         />

--- a/client/src/containers/FundingSourceTimes/FundingSourceTimes.tsx
+++ b/client/src/containers/FundingSourceTimes/FundingSourceTimes.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { Table, Column } from '@ctoec/component-library';
 import { BackButton } from '../../components/BackButton';
-import {
-  FundingSource,
-  FundingSourceTime,
-  FundingSpace,
-  FundingTime,
-} from '../../shared/models';
+import { FundingSource, FundingTime } from '../../shared/models';
 import { FUNDING_SOURCE_TIMES } from '../../shared/constants';
 import { getH1RefForTitle } from '../../utils/getH1RefForTitle';
 


### PR DESCRIPTION
Reformats the table of funding types and contract spaces to use contract spaces as the row indexer for each column (this forces the accepted format text to line up with each contract space). Funding types are then broadcast over multiple rows.

Closes #618 