### PR TITLE
Handle nulls/undefineds

### DIFF
--- a/src/controllers/children/get.ts
+++ b/src/controllers/children/get.ts
@@ -1,4 +1,4 @@
-import { removedDeletedEntitiesFromChild } from '../../utils/filterSoftRemoved';
+import { removeDeletedEntitiesFromChild } from '../../utils/filterSoftRemoved';
 import {
   getManager,
   FindManyOptions,
@@ -8,7 +8,6 @@ import {
 import { User, Child } from '../../entity';
 import { validateObject } from '../../utils/validateObject';
 import { getReadAccessibleOrgIds } from '../../utils/getReadAccessibleOrgIds';
-import { withdraw } from '../enrollments';
 import { Moment } from 'moment';
 
 /**
@@ -20,7 +19,7 @@ import { Moment } from 'moment';
 export const getChildById = async (id: string, user: User): Promise<Child> => {
   const opts = await getFindOpts(user, { id });
   let child = await getManager().findOne(Child, opts);
-  child = removedDeletedEntitiesFromChild(child);
+  child = removeDeletedEntitiesFromChild(child);
 
   return await validateObject(child);
 };
@@ -62,7 +61,7 @@ export const getChildren = async (
   opts.take = take;
 
   let children = await getManager().find(Child, opts);
-  children = children.map((c) => removedDeletedEntitiesFromChild(c));
+  children = children.map((c) => removeDeletedEntitiesFromChild(c));
   children = await Promise.all(children.map(validateObject));
 
   // If withdrawn qs param

--- a/src/utils/filterSoftRemoved.ts
+++ b/src/utils/filterSoftRemoved.ts
@@ -6,8 +6,7 @@ import { Child, Enrollment } from '../entity';
  * soft-deleted.
  * @param rows
  */
-export const removeDeletedElements = (rows: any[]) => {
-  if (!rows) return [];
+export const removeDeletedElements = (rows?: any[]) => {
   return rows.filter((row: any) => !row.deletedDate);
 };
 
@@ -22,12 +21,12 @@ export const removeDeletedEntitiesFromChild = (child: Child) => {
   if (!child) return undefined;
   if (child.family) {
     child.family.incomeDeterminations = removeDeletedElements(
-      child.family.incomeDeterminations || []
+      child.family.incomeDeterminations
     );
   }
-  child.enrollments = removeDeletedElements(child.enrollments || []);
+  child.enrollments = removeDeletedElements(child.enrollments);
   child.enrollments.forEach((e: Enrollment) => {
-    e.fundings = removeDeletedElements(e.fundings || []);
+    e.fundings = removeDeletedElements(e.fundings);
   });
   return child;
 };

--- a/src/utils/filterSoftRemoved.ts
+++ b/src/utils/filterSoftRemoved.ts
@@ -1,13 +1,13 @@
-import { Child, Enrollment, Family } from '../entity';
+import { Child, Enrollment } from '../entity';
 
 /**
  * Given an array of 'rows' (assumed to be a property of some
  * entity), filter out any objects in those rows that have been
  * soft-deleted.
- * @param entity
- * @param property
+ * @param rows
  */
 export const removeDeletedElements = (rows: any[]) => {
+  if (!rows) return [];
   return rows.filter((row: any) => !row.deletedDate);
 };
 
@@ -18,11 +18,13 @@ export const removeDeletedElements = (rows: any[]) => {
  * all remaining enrollments.
  * @param child
  */
-export const removedDeletedEntitiesFromChild = (child: Child) => {
+export const removeDeletedEntitiesFromChild = (child: Child) => {
   if (!child) return undefined;
-  child.family.incomeDeterminations = removeDeletedElements(
-    child.family.incomeDeterminations || []
-  );
+  if (child.family) {
+    child.family.incomeDeterminations = removeDeletedElements(
+      child.family.incomeDeterminations || []
+    );
+  }
   child.enrollments = removeDeletedElements(child.enrollments || []);
   child.enrollments.forEach((e: Enrollment) => {
     e.fundings = removeDeletedElements(e.fundings || []);

--- a/src/utils/filterSoftRemoved.ts
+++ b/src/utils/filterSoftRemoved.ts
@@ -7,6 +7,7 @@ import { Child, Enrollment } from '../entity';
  * @param rows
  */
 export const removeDeletedElements = (rows?: any[]) => {
+  if (!rows) return [];
   return rows.filter((row: any) => !row.deletedDate);
 };
 


### PR DESCRIPTION
Makes soft delete filtering handle if `family`  is undefined, as well as  if  the rows to filter on are  undefined. Closes #770 .
closes #768 
closes #767 