### PR TITLE
489: Add validation for funded enrollment requirement

### DIFF
--- a/client/src/components/Forms/Enrollment/Form.tsx
+++ b/client/src/components/Forms/Enrollment/Form.tsx
@@ -34,6 +34,10 @@ export const doesEnrollmentFormHaveErrors = (
       : false;
   }
 
+  if (child && !!getValidationStatusForFields(child, ['enrollments'])) {
+    return true;
+  }
+
   return child?.enrollments?.length
     ? !!getValidationStatusForFields(child.enrollments, enrollmentFundingFields)
     : true;

--- a/client/src/containers/EditRecord/EditRecord.tsx
+++ b/client/src/containers/EditRecord/EditRecord.tsx
@@ -33,9 +33,11 @@ const EditRecord: React.FC = () => {
 
   // Persist active tab in URL hash
   const activeTab = useLocation().hash.slice(1);
-  // Clear any previously displayed alerts from other tabs
+  // Clear any previously displayed alerts that are not the general missing info alert
   useEffect(() => {
-    setAlerts([]);
+    setAlerts((alerts) => [
+      ...alerts.filter((alert) => alert.heading === MISSING_INFO_ALERT_HEADING),
+    ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeTab]);
   const history = useHistory();
@@ -126,6 +128,7 @@ const EditRecord: React.FC = () => {
   );
 };
 
+const MISSING_INFO_ALERT_HEADING = 'This record has missing or incorrect info';
 const getMissingInfoAlertProps: (child: Child) => AlertProps | undefined = (
   child: Child
 ) => {
@@ -134,15 +137,12 @@ const getMissingInfoAlertProps: (child: Child) => AlertProps | undefined = (
   );
   if (!formsWithErrors.length) return;
 
-  const formsWithErrorsString =
-    formsWithErrors.length > 1
-      ? formsWithErrors.map(({ name }) => name.toLowerCase()).join(', ')
-      : `${formsWithErrors[0].name.toLowerCase()} `;
-  const errorMessage = `Add required info in ${formsWithErrorsString}before submitting your data to OEC.`;
   return {
-    heading: 'This record has missing or incorrect info',
+    heading: MISSING_INFO_ALERT_HEADING,
     type: 'error',
-    text: errorMessage,
+    text: `Add required info in ${formsWithErrors
+      .map((form) => form.name.toLowerCase())
+      .join(', ')} before submitting your data to OEC.`,
   };
 };
 

--- a/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
@@ -6,6 +6,8 @@ import { ChangeFundingCard } from './ChangeFunding/Card';
 import { EditEnrollmentCard } from './EditEnrollmentCard';
 import { Enrollment, Child } from '../../../shared/models';
 import { AlertProps, Alert } from '@ctoec/component-library';
+import { Link } from 'react-router-dom';
+import { SECTION_KEYS } from '../../../components/Forms';
 
 export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
   child,
@@ -26,7 +28,21 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
     ? enrollments.filter((e) => e.id !== currentEnrollment.id)
     : enrollments;
 
+  // TODO: remove this banner alert error, and replace with funding card with
+  // missing info icons - https://github.com/ctoec/data-collection/pull/795#issuecomment-729150524
   const missingFundedEnrollmentError = getMissingFundedEnrollmentError(child);
+  if (missingFundedEnrollmentError) {
+    setAlerts((alerts) => {
+      if (
+        !alerts.find(
+          (alert) => alert.heading === missingFundedEnrollmentError.heading
+        )
+      ) {
+        return [...alerts, missingFundedEnrollmentError];
+      }
+      return alerts;
+    });
+  }
 
   const commonProps = {
     afterSaveSuccess,
@@ -36,11 +52,6 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
 
   return (
     <>
-      {missingFundedEnrollmentError && (
-        <div className="margin-y-1">
-          <Alert {...missingFundedEnrollmentError} />
-        </div>
-      )}
       <h2>Enrollment and funding</h2>
       <ChangeEnrollmentCard
         {...commonProps}
@@ -110,7 +121,16 @@ const getMissingFundedEnrollmentError: (_: Child) => AlertProps | undefined = (
   if (missingFundingError) {
     return {
       type: 'error',
-      text: 'A child must have at least one funded enrollment.',
+      heading: 'This record is missing funding information',
+      text: (
+        <>
+          Records must have at least one current or past funded enrollment to be
+          submitted to OEC. Add funding info in the{' '}
+          <Link to={`/edit-record/${child.id}#${SECTION_KEYS.ENROLLMENT}`}>
+            enrollment and funding section
+          </Link>
+        </>
+      ),
     };
   }
 };

--- a/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
@@ -4,7 +4,8 @@ import { EditFundingCard } from './EditFundingCard';
 import { ChangeEnrollmentCard } from './ChangeEnrollment/Card';
 import { ChangeFundingCard } from './ChangeFunding/Card';
 import { EditEnrollmentCard } from './EditEnrollmentCard';
-import { Enrollment } from '../../../shared/models';
+import { Enrollment, Child } from '../../../shared/models';
+import { AlertProps, Alert } from '@ctoec/component-library';
 
 export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
   child,
@@ -25,6 +26,8 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
     ? enrollments.filter((e) => e.id !== currentEnrollment.id)
     : enrollments;
 
+  const missingFundedEnrollmentError = getMissingFundedEnrollmentError(child);
+
   const commonProps = {
     afterSaveSuccess,
     child,
@@ -33,6 +36,11 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
 
   return (
     <>
+      {missingFundedEnrollmentError && (
+        <div className="margin-y-1">
+          <Alert {...missingFundedEnrollmentError} />
+        </div>
+      )}
       <h2>Enrollment and funding</h2>
       <ChangeEnrollmentCard
         {...commonProps}
@@ -87,4 +95,22 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
       )}
     </>
   );
+};
+
+const getMissingFundedEnrollmentError: (_: Child) => AlertProps | undefined = (
+  child: Child
+) => {
+  const missingFundingError = child.validationErrors?.find(
+    (err) =>
+      err.property === 'enrollments' &&
+      err.constraints &&
+      err.constraints['fundedEnrollment']
+  );
+
+  if (missingFundingError) {
+    return {
+      type: 'error',
+      text: 'A child must have at least one funded enrollment.',
+    };
+  }
 };

--- a/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
@@ -28,22 +28,6 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
     ? enrollments.filter((e) => e.id !== currentEnrollment.id)
     : enrollments;
 
-  // TODO: remove this banner alert error, and replace with funding card with
-  // missing info icons - https://github.com/ctoec/data-collection/pull/795#issuecomment-729150524
-  const missingFundedEnrollmentError = getMissingFundedEnrollmentError(child);
-  if (missingFundedEnrollmentError) {
-    setAlerts((alerts) => {
-      if (
-        !alerts.find(
-          (alert) => alert.heading === missingFundedEnrollmentError.heading
-        )
-      ) {
-        return [...alerts, missingFundedEnrollmentError];
-      }
-      return alerts;
-    });
-  }
-
   const commonProps = {
     afterSaveSuccess,
     child,
@@ -106,31 +90,4 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
       )}
     </>
   );
-};
-
-const getMissingFundedEnrollmentError: (_: Child) => AlertProps | undefined = (
-  child: Child
-) => {
-  const missingFundingError = child.validationErrors?.find(
-    (err) =>
-      err.property === 'enrollments' &&
-      err.constraints &&
-      err.constraints['fundedEnrollment']
-  );
-
-  if (missingFundingError) {
-    return {
-      type: 'error',
-      heading: 'This record is missing funding information',
-      text: (
-        <>
-          Records must have at least one current or past funded enrollment to be
-          submitted to OEC. Add funding info in the{' '}
-          <Link to={`/edit-record/${child.id}#${SECTION_KEYS.ENROLLMENT}`}>
-            enrollment and funding section
-          </Link>
-        </>
-      ),
-    };
-  }
 };

--- a/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
@@ -4,10 +4,7 @@ import { EditFundingCard } from './EditFundingCard';
 import { ChangeEnrollmentCard } from './ChangeEnrollment/Card';
 import { ChangeFundingCard } from './ChangeFunding/Card';
 import { EditEnrollmentCard } from './EditEnrollmentCard';
-import { Enrollment, Child } from '../../../shared/models';
-import { AlertProps, Alert } from '@ctoec/component-library';
-import { Link } from 'react-router-dom';
-import { SECTION_KEYS } from '../../../components/Forms';
+import { Enrollment } from '../../../shared/models';
 
 export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
   child,

--- a/client/src/containers/EditRecord/__snapshots__/EditRecord.test.tsx.snap
+++ b/client/src/containers/EditRecord/__snapshots__/EditRecord.test.tsx.snap
@@ -21,6 +21,32 @@ exports[`EditRecord matches snapshot 1`] = `
       </span>
     </button>
     <div
+      class="usa-alert usa-alert--error grid-row"
+      role="alert"
+    >
+      <div
+        class="display-flex flex-fill"
+      >
+        <div
+          class="usa-alert__body grid-col flex-fill"
+        >
+          <h2
+            class="usa-alert__heading"
+          >
+            This record has missing or incorrect info
+          </h2>
+          <p
+            class="usa-alert__text"
+          >
+            Add required info in enrollment and funding before submitting your data to OEC.
+          </p>
+        </div>
+        <div
+          class="usa-alert__body flex-auto display-flex flex-align-center"
+        />
+      </div>
+    </div>
+    <div
       class="display-flex flex-justify"
     >
       <div>

--- a/src/entity/Child.ts
+++ b/src/entity/Child.ts
@@ -31,6 +31,7 @@ import { ChildRaceIndicated } from './decorators/Child/raceValidation';
 import { ChildGenderSpecified } from './decorators/Child/genderValidation';
 import { MomentComparison } from './decorators/momentValidators';
 import { ChildBirthCertificateSpecified } from './decorators/Child/birthCertificateValidation';
+import { FundedEnrollmentValidation } from './decorators/Child/fundedEnrollmentValidation';
 
 @Entity()
 export class Child implements ChildInterface {
@@ -156,6 +157,7 @@ export class Child implements ChildInterface {
 
   @ValidateNested({ each: true })
   @OneToMany(() => Enrollment, (enrollment) => enrollment.child)
+  @FundedEnrollmentValidation()
   enrollments?: Array<Enrollment>;
 
   @Column(() => UpdateMetaData, { prefix: false })

--- a/src/entity/decorators/Child/fundedEnrollmentValidation.ts
+++ b/src/entity/decorators/Child/fundedEnrollmentValidation.ts
@@ -1,0 +1,38 @@
+import { registerDecorator, ValidationOptions } from 'class-validator';
+import { getManager } from 'typeorm';
+import { Child, Enrollment } from '../../../entity';
+import { removeDeletedElements } from '../../../utils/filterSoftRemoved';
+
+export function FundedEnrollmentValidation(
+  validationOptions?: ValidationOptions
+): PropertyDecorator {
+  return function (object: Object, propertyName: string) {
+    registerDecorator({
+      name: 'fundedEnrollment',
+      target: object.constructor,
+      propertyName: propertyName,
+      options: {
+        message: 'Every child must have at least one funded enrollment',
+        ...validationOptions,
+      },
+      validator: {
+        async validate(_, { object: child }) {
+          const enrollments = await getManager().find(Enrollment, {
+            relations: ['fundings'],
+            where: {
+              childId: (child as Child).id,
+            },
+          });
+
+          enrollments.forEach((enrollment) => {
+            enrollment.fundings = removeDeletedElements(enrollment?.fundings);
+          });
+
+          return enrollments.some(
+            (enrollment) => enrollment.fundings && enrollment.fundings.length
+          );
+        },
+      },
+    });
+  };
+}


### PR DESCRIPTION
put this on top of error boundary b/c it was easier so will make sure that gets merged first.

need eyes on how to do something with the missing funding alert, in absence of the funding card with missing info icons. threw placeholder error alert in there for now. 

closes #489 
closes #580 