### PR TITLE
Disable submit when not in prod

### DIFF
--- a/client/src/containers/Roster/Roster.tsx
+++ b/client/src/containers/Roster/Roster.tsx
@@ -210,7 +210,11 @@ const Roster: React.FC = () => {
                 : 'Send to OEC'
             }
             onClick={submitToOEC}
-            disabled={!query.organization}
+            // TODO: Submit button must be disabled until the app is in a prod environment
+            disabled={
+              !query.organization ||
+              process.env.REACT_APP_STAGE !== 'production'
+            }
           />
         )}
       </FixedBottomBar>

--- a/client/src/containers/Roster/Roster.tsx
+++ b/client/src/containers/Roster/Roster.tsx
@@ -210,11 +210,9 @@ const Roster: React.FC = () => {
                 : 'Send to OEC'
             }
             onClick={submitToOEC}
-            // TODO: Submit button must be disabled until the app is in a prod environment
-            disabled={
-              !query.organization ||
-              process.env.REACT_APP_STAGE !== 'production'
-            }
+            // TODO: Re-enable button in Jan once we're ready for full-go
+            // disabled={!query.organization}
+            disabled={true}
           />
         )}
       </FixedBottomBar>

--- a/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -761,6 +761,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
         </a>
         <button
           class="usa-button"
+          disabled=""
           type="button"
         >
           Send to OEC
@@ -1490,6 +1491,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
         </a>
         <button
           class="usa-button"
+          disabled=""
           type="button"
         >
           Send to OEC

--- a/src/controllers/enrollments.ts
+++ b/src/controllers/enrollments.ts
@@ -1,15 +1,19 @@
 import { removeDeletedElements } from '../utils/filterSoftRemoved';
-import { getManager } from 'typeorm';
+import { getManager, In } from 'typeorm';
 import { ChangeFunding, Withdraw } from '../../client/src/shared/payloads';
-import { Enrollment, ReportingPeriod, Funding } from '../entity';
+import { Enrollment, ReportingPeriod, Funding, User } from '../entity';
+import { getReadAccessibleOrgIds } from '../utils/getReadAccessibleOrgIds';
 import { NotFoundError, BadRequestError } from '../middleware/error/errors';
 
 export const changeFunding = async (
   id: number,
+  user: User,
   changeFundingData: ChangeFunding
 ) => {
+  const readOrgIds = await getReadAccessibleOrgIds(user);
   let enrollment = await getManager().findOne(Enrollment, id, {
     relations: ['fundings'],
+    where: { site: { organizationId: In(readOrgIds) } },
   });
   enrollment.fundings = removeDeletedElements(enrollment.fundings || []);
 
@@ -74,9 +78,15 @@ export const changeFunding = async (
   });
 };
 
-export const withdraw = async (id: number, withdrawData: Withdraw) => {
+export const withdraw = async (
+  id: number,
+  user: User,
+  withdrawData: Withdraw
+) => {
+  const readOrgIds = await getReadAccessibleOrgIds(user);
   let enrollment = await getManager().findOne(Enrollment, id, {
     relations: ['fundings'],
+    where: { site: { organizationId: In(readOrgIds) } },
   });
   enrollment.fundings = removeDeletedElements(enrollment.fundings || []);
 


### PR DESCRIPTION
Disables submitting to OEC while the app isn't live, and also adds some org ID checks to object creation / updates / gets.
Closes #634 
Closes #779 

I might be missing some of the context for the Org ID check ticket because where I was looking, it seems like we already mostly have that in place (i.e. the child controllers do org checks, the funding controller does checks, most of the routes already filter, etc.). I just wound up updating families, income determinations, and enrollments (although that might've been the point in hindsight).