### PR TITLE
Tweaks 11/18

### DIFF
--- a/src/controllers/enrollmentReports/map.ts
+++ b/src/controllers/enrollmentReports/map.ts
@@ -103,6 +103,7 @@ const mapRow = async (
     organization,
     site,
     childToUpdate,
-    user
+    user,
+    save
   );
 };

--- a/src/data/initialize.ts
+++ b/src/data/initialize.ts
@@ -1,5 +1,19 @@
 import { getManager } from 'typeorm';
-import { Organization, Site, FundingSpace, ReportingPeriod } from '../entity';
+import {
+  Organization,
+  Site,
+  FundingSpace,
+  ReportingPeriod,
+  Funding,
+  Enrollment,
+  Child,
+  Family,
+  IncomeDetermination,
+  SitePermission,
+  OrganizationPermission,
+  EnrollmentReport,
+  User,
+} from '../entity';
 import { FundingSource } from '../../client/src/shared/models';
 import {
   getReportingPeriodFromDates,
@@ -8,8 +22,54 @@ import {
 import { organizations } from './organizations';
 import { sitesByOrgName } from './sites';
 import { getFakeFundingSpaces } from './fundingSpace';
+import { isDevelopment } from '../utils/isDevelopment';
 
 export const initialize = async () => {
+  if (!isDevelopment()) {
+    await getManager().createQueryBuilder().delete().from(Funding).execute();
+    await getManager().createQueryBuilder().delete().from(Enrollment).execute();
+    await getManager().createQueryBuilder().delete().from(Child).execute();
+    await getManager()
+      .createQueryBuilder()
+      .delete()
+      .from(IncomeDetermination)
+      .execute();
+    await getManager().createQueryBuilder().delete().from(Family).execute();
+
+    await getManager()
+      .createQueryBuilder()
+      .delete()
+      .from(EnrollmentReport)
+      .execute();
+
+    await getManager()
+      .createQueryBuilder()
+      .delete()
+      .from(SitePermission)
+      .execute();
+    await getManager()
+      .createQueryBuilder()
+      .delete()
+      .from(OrganizationPermission)
+      .execute();
+    await getManager().createQueryBuilder().delete().from(User).execute();
+    await getManager().createQueryBuilder().delete().from(Site).execute();
+    await getManager()
+      .createQueryBuilder()
+      .delete()
+      .from(FundingSpace)
+      .execute();
+    await getManager()
+      .createQueryBuilder()
+      .delete()
+      .from(Organization)
+      .execute();
+    await getManager()
+      .createQueryBuilder()
+      .delete()
+      .from(ReportingPeriod)
+      .execute();
+  }
   await Promise.all(
     organizations.map(async (orgToCreate) => {
       let organization = await getManager().findOne(Organization, {

--- a/src/migration/1605749736657-UpdateOrganizationFixUniqueIdTypeDefault.ts
+++ b/src/migration/1605749736657-UpdateOrganizationFixUniqueIdTypeDefault.ts
@@ -1,18 +1,24 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class UpdateOrganizationFixUniqueIdTypeDefault1605749736657 implements MigrationInterface {
-    name = 'UpdateOrganizationFixUniqueIdTypeDefault1605749736657'
+export class UpdateOrganizationFixUniqueIdTypeDefault1605749736657
+  implements MigrationInterface {
+  name = 'UpdateOrganizationFixUniqueIdTypeDefault1605749736657';
 
-    public async up(queryRunner: QueryRunner): Promise<void> {
-				const result = await queryRunner.query(`SELECT name FROM sysobjects WHERE name LIKE 'DF__organizat__uniqu%'`);
-				const constraintName = (result[0] as { name: string}).name;
-				await queryRunner.query(`ALTER TABLE "organization" DROP CONSTRAINT "${constraintName}"`);
-				await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN "uniqueIdType"`);
-				await queryRunner.query(`ALTER TABLE "organization" ADD "uniqueIdType" varchar(10) NOT NULL DEFAULT 'Other'`);
-			
-    }
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    const result = await queryRunner.query(
+      `SELECT name FROM sysobjects WHERE name LIKE 'DF__organizat__uniqu%'`
+    );
+    const constraintName = (result[0] as { name: string }).name;
+    await queryRunner.query(
+      `ALTER TABLE "organization" DROP CONSTRAINT "${constraintName}"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organization" DROP COLUMN "uniqueIdType"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "organization" ADD "uniqueIdType" varchar(10) NOT NULL DEFAULT 'Other'`
+    );
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<void> {
-    }
-
+  public async down(queryRunner: QueryRunner): Promise<void> {}
 }

--- a/src/migration/1605749736657-UpdateOrganizationFixUniqueIdTypeDefault.ts
+++ b/src/migration/1605749736657-UpdateOrganizationFixUniqueIdTypeDefault.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class UpdateOrganizationFixUniqueIdTypeDefault1605749736657 implements MigrationInterface {
+    name = 'UpdateOrganizationFixUniqueIdTypeDefault1605749736657'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+				const result = await queryRunner.query(`SELECT name FROM sysobjects WHERE name LIKE 'DF__organizat__uniqu%'`);
+				const constraintName = (result[0] as { name: string}).name;
+				await queryRunner.query(`ALTER TABLE "organization" DROP CONSTRAINT "${constraintName}"`);
+				await queryRunner.query(`ALTER TABLE "organization" DROP COLUMN "uniqueIdType"`);
+				await queryRunner.query(`ALTER TABLE "organization" ADD "uniqueIdType" varchar(10) NOT NULL DEFAULT 'Other'`);
+			
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+    }
+
+}

--- a/src/routes/enrollmentReports.ts
+++ b/src/routes/enrollmentReports.ts
@@ -40,7 +40,7 @@ enrollmentReportsRouter.post(
           reportRows,
           req.user,
           { save: false }
-				);
+        );
         const childrenWithErrors = await Promise.all(
           reportChildren.map(async (child) => {
             return {
@@ -52,9 +52,9 @@ enrollmentReportsRouter.post(
         );
         const errorDict = await controller.checkErrorsInChildren(
           childrenWithErrors
-				);
-				
-				res.send(errorDict);
+        );
+
+        res.send(errorDict);
       } catch (err) {
         if (err instanceof ApiError) throw err;
 
@@ -65,9 +65,9 @@ enrollmentReportsRouter.post(
         throw new BadRequestError(
           'Your file isn’t in the correct format. Use the spreadsheet template without changing the headers.'
         );
-			} finally {
-				if(req.file && req.file.path) fs.unlinkSync(req.file.path);
-			}
+      } finally {
+        if (req.file && req.file.path) fs.unlinkSync(req.file.path);
+      }
     });
   })
 );
@@ -130,9 +130,9 @@ enrollmentReportsRouter.post(
         throw new BadRequestError(
           'Your file isn’t in the correct format. Use the spreadsheet template without changing the headers.'
         );
-			} finally {
-				if(req.file && req.file.path) fs.unlinkSync(req.file.path);
-			}
+      } finally {
+        if (req.file && req.file.path) fs.unlinkSync(req.file.path);
+      }
     });
   })
 );


### PR DESCRIPTION
1. Closes #792 
     - fixes bad default value in organization table for uniqueIdType column 
     - fixes is identifier match check by doing double-equals comparison of sasid/unique id fields to account for null/undefined 
     - Fixes up the update child stuff so that we don't try to save entities when we shouldn't and all entities that need Ids have them 

~1. Reduces the number of network requests the Roster page makes:
    - condenses the withdrawn/active enrollments request into one, since we always get both from the roster home page
    - makes the useOrgSiteProps hook return things as state variable, which for whatever reason drastically cut down on number of requests issued~ this turned into a melodrama, and we will figure out a more robust fix not at 11 pm

~1. Makes sure that on refetch of data, all pages are re-fetched:
    - adds some more weird logic to usePaginatedChildData hook~ same as above

2. Makes data fully recreate in deployed envs, and makes default test user that's created by app have single-org (Hogwarts) permissions

3. Makes enrollment reports controller clean up /tmp upload files afte rthey're parsed