### PR TITLE
Do withdraw filtering in the frontend,

### DIFF
--- a/client/src/containers/DataRequirements/DataRequirements.test.tsx
+++ b/client/src/containers/DataRequirements/DataRequirements.test.tsx
@@ -51,7 +51,8 @@ describe('DataRequirements', () => {
   };
   snapshotTestHelper(<DataRequirements />, {
     ...helperOpts,
-    // Mystery about useSWR in tests. See `Roster.test.tsx` for more in-depth info
+    // Mystery about useSWR in tests (clearing the cache doesn't seem to work, and so
+    // the api fetch only occurs 1x per test sutie)
     before: () => waitFor(() => expect(apiMock.apiGet).toBeCalled()),
   });
   accessibilityTestHelper(<DataRequirements />, helperOpts);

--- a/client/src/containers/PrivacyPolicy/PrivacyPolicy.test.tsx
+++ b/client/src/containers/PrivacyPolicy/PrivacyPolicy.test.tsx
@@ -52,7 +52,8 @@ describe('PrivacyPolicy', () => {
   };
   snapshotTestHelper(<PrivacyPolicy />, {
     ...helperOpts,
-    // Mystery about useSWR in tests. See `Roster.test.tsx` for more in-depth info
+    // Mystery about useSWR in tests (clearing the cache doesn't seem to work, and so
+    // the api fetch only occurs 1x per test sutie)
     before: () => waitFor(() => expect(apiMock.apiGet).toBeCalled()),
   });
   accessibilityTestHelper(<PrivacyPolicy />, helperOpts);

--- a/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
         <p
           class="font-body-xl margin-top-1"
         >
-          4 children enrolled
+          3 children enrolled
         </p>
       </div>
       <div
@@ -74,7 +74,16 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                   </div>
                 </button>
               </div>
-              Placeholder for CSVExcelDownloadButton
+              <button
+                class="usa-button usa-button--unstyled text-bold display-block"
+                type="button"
+              >
+                <span
+                  class="oec-text-with-icon text-underline"
+                >
+                  Export roster
+                </span>
+              </button>
             </div>
           </td>
         </tr>
@@ -180,249 +189,13 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
               <span
                 class="text-light"
               >
-                 4 children
+                 3 children
               </span>
             </h2>
             <div
               aria-multiselectable="true"
               class="oec-accordion"
             >
-              <div
-                class="oec-accordion__heading"
-              >
-                <button
-                  aria-controls="Incomplete-enrollments"
-                  aria-expanded="true"
-                  class="oec-accordion__button"
-                >
-                  <div
-                    class="display-flex flex-justify flex-col flex-align-center padding-top-3 padding-bottom-3"
-                  >
-                    <div>
-                      <h3
-                        class="oec-accordion__heading-title"
-                      >
-                        <span
-                          class="oec-inline-icon oec-inline-icon--attentionNeeded"
-                        >
-                          <span
-                            class="usa-sr-only"
-                          >
-                            (attention needed)
-                          </span>
-                        </span>
-                        Incomplete enrollments 
-                        <span
-                          class="text-normal"
-                        >
-                          1 child 
-                        </span>
-                        <br />
-                        <p
-                          class="usa-error-message margin-y-0 font-body-md"
-                        >
-                          All records must have an assigned age group
-                        </p>
-                      </h3>
-                      <div
-                        class="display-flex flex-wrap"
-                      />
-                    </div>
-                    <div
-                      class="oec-accordion__heading-expand"
-                    >
-                      Hide Incomplete enrollments roster
-                    </div>
-                  </div>
-                </button>
-              </div>
-              <div
-                aria-hidden="false"
-                class="oec-accordion__content"
-                id="Incomplete-enrollments"
-              >
-                <table
-                  class="oec-table margin-bottom-4"
-                  id="roster-table-Incomplete enrollments"
-                >
-                  <thead>
-                    <tr>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-sorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 20%;"
-                      >
-                        <button
-                          aria-label="Sort table by Name in descending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Name
-                          <div
-                            class="oec-table__sort-controls oec-table__sort-controls--ascending"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs break-spaces"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Missing info in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Missing info
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Birthdate in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Birthdate
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Funding type in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Funding type
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Space type in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Space type
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 20%;"
-                      >
-                        <button
-                          aria-label="Sort table by Site in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Site
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 20%;"
-                      >
-                        <button
-                          aria-label="Sort table by Organization in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Organization
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs break-spaces"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Enrollment date in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Enrollment date
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th
-                        class="font-body-2xs"
-                        scope="row"
-                      >
-                        <a
-                          class="usa-button usa-button--unstyled font-body-2xs text-no-wrap"
-                          href="/edit-record/undefined"
-                        >
-                          ,  
-                        </a>
-                      </th>
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs ellipsis-wrap-text ellipsis-wrap-text--tight"
-                      />
-                      <td
-                        class="font-body-2xs ellipsis-wrap-text ellipsis-wrap-text--tight"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
               <div
                 class="oec-accordion__heading"
               >
@@ -1010,7 +783,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
         <p
           class="font-body-xl margin-top-1"
         >
-          4 children enrolled at 2 sites
+          3 children enrolled at 2 sites
         </p>
       </div>
       <div
@@ -1041,7 +814,16 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                   Add a record
                 </span>
               </a>
-              Placeholder for CSVExcelDownloadButton
+              <button
+                class="usa-button usa-button--unstyled text-bold display-block"
+                type="button"
+              >
+                <span
+                  class="oec-text-with-icon text-underline"
+                >
+                  Export roster
+                </span>
+              </button>
             </div>
           </td>
         </tr>
@@ -1158,229 +940,13 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
               <span
                 class="text-light"
               >
-                 4 children
+                 3 children
               </span>
             </h2>
             <div
               aria-multiselectable="true"
               class="oec-accordion"
             >
-              <div
-                class="oec-accordion__heading"
-              >
-                <button
-                  aria-controls="Incomplete-enrollments"
-                  aria-expanded="true"
-                  class="oec-accordion__button"
-                >
-                  <div
-                    class="display-flex flex-justify flex-col flex-align-center padding-top-3 padding-bottom-3"
-                  >
-                    <div>
-                      <h3
-                        class="oec-accordion__heading-title"
-                      >
-                        <span
-                          class="oec-inline-icon oec-inline-icon--attentionNeeded"
-                        >
-                          <span
-                            class="usa-sr-only"
-                          >
-                            (attention needed)
-                          </span>
-                        </span>
-                        Incomplete enrollments 
-                        <span
-                          class="text-normal"
-                        >
-                          1 child 
-                        </span>
-                        <br />
-                        <p
-                          class="usa-error-message margin-y-0 font-body-md"
-                        >
-                          All records must have an assigned age group
-                        </p>
-                      </h3>
-                      <div
-                        class="display-flex flex-wrap"
-                      />
-                    </div>
-                    <div
-                      class="oec-accordion__heading-expand"
-                    >
-                      Hide Incomplete enrollments roster
-                    </div>
-                  </div>
-                </button>
-              </div>
-              <div
-                aria-hidden="false"
-                class="oec-accordion__content"
-                id="Incomplete-enrollments"
-              >
-                <table
-                  class="oec-table margin-bottom-4"
-                  id="roster-table-Incomplete enrollments"
-                >
-                  <thead>
-                    <tr>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-sorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 25%;"
-                      >
-                        <button
-                          aria-label="Sort table by Name in descending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Name
-                          <div
-                            class="oec-table__sort-controls oec-table__sort-controls--ascending"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs break-spaces"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Missing info in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Missing info
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Birthdate in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Birthdate
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Funding type in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Funding type
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Space type in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Space type
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 25%;"
-                      >
-                        <button
-                          aria-label="Sort table by Site in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Site
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                      <th
-                        aria-sort="ascending"
-                        class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs break-spaces"
-                        role="columnheader"
-                        scope="col"
-                        style="width: 10%;"
-                      >
-                        <button
-                          aria-label="Sort table by Enrollment date in ascending order"
-                          class="oec-table__column-title usa-button--unstyled width-full"
-                        >
-                          Enrollment date
-                          <div
-                            class="oec-table__sort-controls"
-                          />
-                        </button>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <th
-                        class="font-body-2xs"
-                        scope="row"
-                      >
-                        <a
-                          class="usa-button usa-button--unstyled font-body-2xs text-no-wrap"
-                          href="/edit-record/undefined"
-                        >
-                          ,  
-                        </a>
-                      </th>
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                      <td
-                        class="font-body-2xs ellipsis-wrap-text ellipsis-wrap-text--tight"
-                      />
-                      <td
-                        class="font-body-2xs"
-                      />
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
               <div
                 class="oec-accordion__heading"
               >
@@ -1930,7 +1496,7 @@ exports[`Roster matches snapshot for site level user 1`] = `
         <p
           class="font-body-xl margin-top-1"
         >
-          4 children enrolled
+          3 children enrolled
         </p>
       </div>
       <div
@@ -1961,7 +1527,16 @@ exports[`Roster matches snapshot for site level user 1`] = `
                   Add a record
                 </span>
               </a>
-              Placeholder for CSVExcelDownloadButton
+              <button
+                class="usa-button usa-button--unstyled text-bold display-block"
+                type="button"
+              >
+                <span
+                  class="oec-text-with-icon text-underline"
+                >
+                  Export roster
+                </span>
+              </button>
             </div>
           </td>
         </tr>
@@ -2011,222 +1586,6 @@ exports[`Roster matches snapshot for site level user 1`] = `
           aria-multiselectable="true"
           class="oec-accordion"
         >
-          <div
-            class="oec-accordion__heading"
-          >
-            <button
-              aria-controls="Incomplete-enrollments"
-              aria-expanded="true"
-              class="oec-accordion__button"
-            >
-              <div
-                class="display-flex flex-justify flex-col flex-align-center padding-top-3 padding-bottom-3"
-              >
-                <div>
-                  <h2
-                    class="oec-accordion__heading-title"
-                  >
-                    <span
-                      class="oec-inline-icon oec-inline-icon--attentionNeeded"
-                    >
-                      <span
-                        class="usa-sr-only"
-                      >
-                        (attention needed)
-                      </span>
-                    </span>
-                    Incomplete enrollments 
-                    <span
-                      class="text-normal"
-                    >
-                      1 child 
-                    </span>
-                    <br />
-                    <p
-                      class="usa-error-message margin-y-0 font-body-md"
-                    >
-                      All records must have an assigned age group
-                    </p>
-                  </h2>
-                  <div
-                    class="display-flex flex-wrap"
-                  />
-                </div>
-                <div
-                  class="oec-accordion__heading-expand"
-                >
-                  Hide Incomplete enrollments roster
-                </div>
-              </div>
-            </button>
-          </div>
-          <div
-            aria-hidden="false"
-            class="oec-accordion__content"
-            id="Incomplete-enrollments"
-          >
-            <table
-              class="oec-table margin-bottom-4"
-              id="roster-table-Incomplete enrollments"
-            >
-              <thead>
-                <tr>
-                  <th
-                    aria-sort="ascending"
-                    class="oec-table__column-header oec-sortable oec-sorted text-pre text-center font-body-2xs"
-                    role="columnheader"
-                    scope="col"
-                    style="width: 25%;"
-                  >
-                    <button
-                      aria-label="Sort table by Name in descending order"
-                      class="oec-table__column-title usa-button--unstyled width-full"
-                    >
-                      Name
-                      <div
-                        class="oec-table__sort-controls oec-table__sort-controls--ascending"
-                      />
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="ascending"
-                    class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs break-spaces"
-                    role="columnheader"
-                    scope="col"
-                    style="width: 10%;"
-                  >
-                    <button
-                      aria-label="Sort table by Missing info in ascending order"
-                      class="oec-table__column-title usa-button--unstyled width-full"
-                    >
-                      Missing info
-                      <div
-                        class="oec-table__sort-controls"
-                      />
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="ascending"
-                    class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                    role="columnheader"
-                    scope="col"
-                    style="width: 10%;"
-                  >
-                    <button
-                      aria-label="Sort table by Birthdate in ascending order"
-                      class="oec-table__column-title usa-button--unstyled width-full"
-                    >
-                      Birthdate
-                      <div
-                        class="oec-table__sort-controls"
-                      />
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="ascending"
-                    class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                    role="columnheader"
-                    scope="col"
-                    style="width: 10%;"
-                  >
-                    <button
-                      aria-label="Sort table by Funding type in ascending order"
-                      class="oec-table__column-title usa-button--unstyled width-full"
-                    >
-                      Funding type
-                      <div
-                        class="oec-table__sort-controls"
-                      />
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="ascending"
-                    class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                    role="columnheader"
-                    scope="col"
-                    style="width: 10%;"
-                  >
-                    <button
-                      aria-label="Sort table by Space type in ascending order"
-                      class="oec-table__column-title usa-button--unstyled width-full"
-                    >
-                      Space type
-                      <div
-                        class="oec-table__sort-controls"
-                      />
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="ascending"
-                    class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs"
-                    role="columnheader"
-                    scope="col"
-                    style="width: 25%;"
-                  >
-                    <button
-                      aria-label="Sort table by Site in ascending order"
-                      class="oec-table__column-title usa-button--unstyled width-full"
-                    >
-                      Site
-                      <div
-                        class="oec-table__sort-controls"
-                      />
-                    </button>
-                  </th>
-                  <th
-                    aria-sort="ascending"
-                    class="oec-table__column-header oec-sortable oec-unsorted text-pre text-center font-body-2xs break-spaces"
-                    role="columnheader"
-                    scope="col"
-                    style="width: 10%;"
-                  >
-                    <button
-                      aria-label="Sort table by Enrollment date in ascending order"
-                      class="oec-table__column-title usa-button--unstyled width-full"
-                    >
-                      Enrollment date
-                      <div
-                        class="oec-table__sort-controls"
-                      />
-                    </button>
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <th
-                    class="font-body-2xs"
-                    scope="row"
-                  >
-                    <a
-                      class="usa-button usa-button--unstyled font-body-2xs text-no-wrap"
-                      href="/edit-record/undefined"
-                    >
-                      ,  
-                    </a>
-                  </th>
-                  <td
-                    class="font-body-2xs"
-                  />
-                  <td
-                    class="font-body-2xs"
-                  />
-                  <td
-                    class="font-body-2xs"
-                  />
-                  <td
-                    class="font-body-2xs"
-                  />
-                  <td
-                    class="font-body-2xs ellipsis-wrap-text ellipsis-wrap-text--tight"
-                  />
-                  <td
-                    class="font-body-2xs"
-                  />
-                </tr>
-              </tbody>
-            </table>
-          </div>
           <div
             class="oec-accordion__heading"
           >

--- a/client/src/containers/Roster/hooks/usePaginatedChildData.tsx
+++ b/client/src/containers/Roster/hooks/usePaginatedChildData.tsx
@@ -33,7 +33,6 @@ export const usePaginatedChildData = (query: RosterQueryParams) => {
           organizationId: query.organization,
           skip: index * PAGE_SIZE,
           take: PAGE_SIZE,
-          withdrawn: query.withdrawn,
           month: query.month,
         })}`
       : null;

--- a/client/src/containers/Roster/rosterUtils.tsx
+++ b/client/src/containers/Roster/rosterUtils.tsx
@@ -15,6 +15,20 @@ import { RosterQueryParams } from './Roster';
 const MAX_LENGTH_EXPANDED = 50;
 export const QUERY_STRING_MONTH_FORMAT = 'MMMM-YYYY';
 
+export const filterChildrenByWithdrawn = (children: Child[]) => {
+  return children.reduce(
+    (filteredChildren, child) => {
+      if (child.enrollments?.every((enrollment) => !!enrollment.exit)) {
+        filteredChildren.withdrawn.push(child);
+      } else {
+        filteredChildren.active.push(child);
+      }
+      return filteredChildren;
+    },
+    { active: [] as Child[], withdrawn: [] as Child[] }
+  );
+};
+
 /**
  * Get month param in query string month format
  * @param month

--- a/src/controllers/children/get.ts
+++ b/src/controllers/children/get.ts
@@ -27,7 +27,6 @@ export const getChildById = async (id: string, user: User): Promise<Child> => {
  * Get all children the given user has access to.
  * Optionally, can filter to only return children:
  * 	- for specific organizations
- *  - who are totally withdrawn (no active enrollments)
  *  - with active enrollments in a specific month
  * 	- with missing info
  * Supports pagination with skip and take parameters, which
@@ -39,7 +38,6 @@ export const getChildren = async (
   filterOpts: {
     organizationIds?: string[];
     missingInfoOnly?: boolean;
-    withdrawnOnly?: boolean;
     activeMonth?: Moment;
     skip?: number;
     take?: number;
@@ -48,7 +46,6 @@ export const getChildren = async (
   let {
     organizationIds,
     missingInfoOnly,
-    withdrawnOnly,
     activeMonth,
     skip,
     take,
@@ -70,11 +67,6 @@ export const getChildren = async (
       (child) => child.validationErrors && child.validationErrors.length
     );
   }
-  // Else if withdrawn qs param
-  else if (withdrawnOnly) {
-    // Do not return any children with active enrollments
-    return children.filter((c) => c.enrollments?.every((e) => !!e.exit));
-  }
   // Else if month qs param
   else if (activeMonth) {
     // Do not return children withouth active enrollment during or before that month
@@ -88,10 +80,9 @@ export const getChildren = async (
       return c.enrollments && c.enrollments.length;
     });
   }
-  // Else default to return only children with active enrollments
-  else {
-    return children.filter((c) => c.enrollments?.some((e) => !e.exit));
-  }
+
+  // Default return all children
+  return children;
 };
 
 /**

--- a/src/routes/children.ts
+++ b/src/routes/children.ts
@@ -25,7 +25,6 @@ childrenRouter.get(
     }) as string[];
     const count = parseQueryString(req, 'count');
     const missingInfo = parseQueryString(req, 'missing-info') as string;
-    const withdrawn = parseQueryString(req, 'withdrawn') as string;
     const activeMonth = parseQueryString(req, 'month', {
       post: (monthStr) => moment.utc(monthStr, 'MMM-YYYY'),
     }) as Moment;
@@ -41,7 +40,6 @@ childrenRouter.get(
     const children = await controller.getChildren(req.user, {
       organizationIds,
       missingInfoOnly: missingInfo === 'true',
-      withdrawnOnly: withdrawn === 'true',
       activeMonth,
       skip,
       take,


### PR DESCRIPTION
 since we always fetch all of the enrollments anyway; might as well save the duplicative work

Also fixes a bug where children with no enrollments were no showing up
in the roster ever

also makes roster tests mock smarter