### PR TITLE
Fix header error

### DIFF
--- a/src/routes/template.ts
+++ b/src/routes/template.ts
@@ -69,9 +69,7 @@ templateRouter.get(
       } else if (whichFakeChildren === 'missingOne') {
         fakeChildren = childrenAllMissingOneField;
       }
-      res.send(
-        await streamUploadedChildren(res, fakeChildren, fileType as BookType)
-      );
+      await streamUploadedChildren(res, fakeChildren, fileType as BookType);
     } catch (err) {
       console.error('Unable to download example', err);
       throw new InternalServerError('Could not download example file: ' + err);


### PR DESCRIPTION
Issue was caused by having two `res.send()` calls, resulting in the system trying to unexpectedly send a response after one response was already formatted and written (`streamTabularData` sets the content type and sends, and then the route was trying to send again with an empty body because `streamTabularData` doesn't return anything, which created the `cannot Remove headers` bug). Closes #835 .