### PR TITLE
Set alerts to empty array if there are no children with errors

### DIFF
--- a/client/src/containers/Roster/Roster.tsx
+++ b/client/src/containers/Roster/Roster.tsx
@@ -246,7 +246,7 @@ const Roster: React.FC = () => {
           </div>
         </div>
         <ErrorBoundary alertProps={{ ...defaultErrorBoundaryProps }}>
-          {rosterIsEmpty ? <></> : buttonTable}
+          {!rosterIsEmpty && buttonTable}
           <LoadingWrapper text="Loading your roster..." loading={loading}>
             {rosterContent}
           </LoadingWrapper>

--- a/client/src/containers/Roster/hooks/useChildrenWithErrorsAlert.tsx
+++ b/client/src/containers/Roster/hooks/useChildrenWithErrorsAlert.tsx
@@ -30,11 +30,6 @@ export const useChildrenWithErrorsAlert = (
       return;
     }
 
-    if (!childrenWithErrorsCount) {
-      setAlerts([]);
-      return;
-    }
-
     // set alert if:
     // - no existing matching alert OR
     // - existing matching alert has different number (i.e. was displaying content for a different organization)
@@ -42,18 +37,26 @@ export const useChildrenWithErrorsAlert = (
       (a) => a.heading === childrenWithErrorsAlert.heading
     );
     const existingAlertText = drillReactNodeForText(existingAlert?.text);
+    const otherAlerts = alerts.filter(
+      (a) => a.heading !== childrenWithErrorsAlert.heading
+    );
+
+    if (!childrenWithErrorsCount) {
+      // If there are no longer children with errors, we need to ditch that alert without overwriting alerts that may have come from other pages (ie. after delete child)
+      setAlerts(otherAlerts);
+      return;
+    }
+
     if (
       !existingAlert ||
       !existingAlertText.includes(`${childrenWithErrorsCount}`)
     ) {
-      setAlerts([
-        ...alerts.filter((a) => a.heading !== childrenWithErrorsAlert.heading),
-        childrenWithErrorsAlert,
-      ]);
+      setAlerts([...otherAlerts, childrenWithErrorsAlert]);
     }
   }, [childrenWithErrorsCount, isLoading, alertType]);
 
-  if (isLoading || !childrenWithErrorsCount) return {};
+  // If data is loading, we shouldn't display any alerts
+  if (isLoading) return {};
   return { alertElements };
 };
 

--- a/client/src/containers/Roster/hooks/useChildrenWithErrorsAlert.tsx
+++ b/client/src/containers/Roster/hooks/useChildrenWithErrorsAlert.tsx
@@ -22,11 +22,16 @@ export const useChildrenWithErrorsAlert = (
     organizationId
   );
   useEffect(() => {
-    if (isLoading || !childrenWithErrorsCount) {
+    if (isLoading) {
       // TODO: This line for some reason needs to exist so that Roster.test.tsx can
       // pass with the jestFunc() apiMock call, but it in theory shouldn't need to.
       // Investigate weirdness later.
       setAlerts([...alerts]);
+      return;
+    }
+
+    if (!childrenWithErrorsCount) {
+      setAlerts([]);
       return;
     }
 
@@ -48,6 +53,7 @@ export const useChildrenWithErrorsAlert = (
     }
   }, [childrenWithErrorsCount, isLoading, alertType]);
 
+  if (isLoading || !childrenWithErrorsCount) return {};
   return { alertElements };
 };
 


### PR DESCRIPTION
Closes #969 

There's still a little delay where the alert shows, I think bc of how caching is working (i.e. for the same reason that we see stale children values for a mo' when the roster loads).