### PR TITLE
Only show one alert for missing funding

### DIFF
--- a/client/src/containers/EditRecord/EditRecord.tsx
+++ b/client/src/containers/EditRecord/EditRecord.tsx
@@ -70,7 +70,7 @@ const EditRecord: React.FC = () => {
           updatedChild
         );
         if (missingFundedEnrollmentAlertProps) {
-          newAlerts.push(missingFundedEnrollmentAlertProps);
+          newAlerts.splice(0, 1, missingFundedEnrollmentAlertProps);
         }
 
         // Only set success alert on a GET that happens after an update (refetch count > 0)


### PR DESCRIPTION
Closes #967 

@RyanHansz I took the AC to mean that there should only be one alert showing when funding info is missing-- even if there is other info missing.  Is that what you meant?