### PR TITLE
Adds values for existing income dets

### DIFF
--- a/src/entity/IncomeDetermination.ts
+++ b/src/entity/IncomeDetermination.ts
@@ -35,7 +35,6 @@ export class IncomeDetermination implements IncomeDeterminationInterface {
   determinationDate?: Moment;
 
   @Column({ nullable: true })
-  @IsNotEmpty()
   incomeNotDisclosed?: boolean;
 
   @ManyToOne((_) => Family, { nullable: false })

--- a/src/migration/1608582587797-AddIncomeNotDisclosedToFamily.ts
+++ b/src/migration/1608582587797-AddIncomeNotDisclosedToFamily.ts
@@ -1,4 +1,5 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
+import { dropDefaultConstraint } from './utils/dropDefaultConstraint';
 
 export class AddIncomeNotDisclosedToFamily1608582587797
   implements MigrationInterface {
@@ -6,11 +7,16 @@ export class AddIncomeNotDisclosedToFamily1608582587797
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(
-      `ALTER TABLE "income_determination" ADD "incomeNotDisclosed" bit`
+      `ALTER TABLE "income_determination" ADD "incomeNotDisclosed" bit DEFAULT(0) WITH VALUES`
     );
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    await dropDefaultConstraint(
+      queryRunner,
+      'income_determination',
+      'incomeNotDisclosed'
+    );
     await queryRunner.query(
       `ALTER TABLE "income_determination" DROP COLUMN "incomeNotDisclosed"`
     );


### PR DESCRIPTION
wondering how others feel about the merits of having validation errors around "incomeNotDisclosed" ? I don't know that it actually is useful, but maybe it is? happy to put it back, since this change to the DML prevents the bad state