### PR TITLE
Fix upload parsing error

### DIFF
--- a/src/entity/Enrollment.ts
+++ b/src/entity/Enrollment.ts
@@ -93,7 +93,7 @@ export class Enrollment implements EnrollmentInterface {
   @ValidateIf((enrollment) => {
     // This is used by each funding
     // See similar pattern between child and family
-    enrollment.fundings.forEach((funding) => {
+    enrollment.fundings?.forEach((funding) => {
       // Fundings must be undefined or we have circular json
       funding.enrollment = { ...enrollment, fundings: undefined };
       // But we still need access to the other fundings

--- a/src/routes/enrollmentReports.ts
+++ b/src/routes/enrollmentReports.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import { getManager } from 'typeorm';
 import multer from 'multer';
-import { Child, EnrollmentReport } from '../entity';
 import {
   BadRequestError,
   ApiError,
@@ -54,10 +53,12 @@ enrollmentReportsRouter.post(
           childrenWithErrors
         );
 
+        // Only remove the file from disk if we could successfully parse it
+        if (req.file && req.file.path) fs.unlinkSync(req.file.path);
+
         res.send(errorDict);
       } catch (err) {
         if (err instanceof ApiError) throw err;
-
         console.error(
           'Unable to determine validation errors in spreadsheet: ',
           err
@@ -65,8 +66,6 @@ enrollmentReportsRouter.post(
         throw new BadRequestError(
           'Your file isn’t in the correct format. Use the spreadsheet template without changing the headers.'
         );
-      } finally {
-        if (req.file && req.file.path) fs.unlinkSync(req.file.path);
       }
     });
   })
@@ -136,15 +135,15 @@ enrollmentReportsRouter.post(
           active: numActive,
           withdrawn: numWithdrawn,
         } as BatchUpload);
+
+        // Only remove the file from disk if we successfully parsed it
+        if (req.file && req.file.path) fs.unlinkSync(req.file.path);
       } catch (err) {
         if (err instanceof ApiError) throw err;
-
         console.error('Error parsing uploaded enrollment report: ', err);
         throw new BadRequestError(
           'Your file isn’t in the correct format. Use the spreadsheet template without changing the headers.'
         );
-      } finally {
-        if (req.file && req.file.path) fs.unlinkSync(req.file.path);
       }
     });
   })

--- a/src/routes/enrollmentReports.ts
+++ b/src/routes/enrollmentReports.ts
@@ -13,7 +13,15 @@ import fs from 'fs';
 import { BatchUpload } from '../../client/src/shared/payloads';
 
 export const enrollmentReportsRouter = express.Router();
-const upload = multer({ dest: '/tmp/uploads' }).single('file');
+
+// Save uploaded files with timestamps so that if one fails and
+// it persists to disk, it's easier to debug
+const storage = multer.diskStorage({
+  destination: '/tmp/uploads',
+  filename: (req, file, callback) =>
+    callback(null, file.fieldname + '_' + new Date()),
+});
+const upload = multer({ storage: storage }).single('file');
 
 /**
  * /enrollment-reports/check POST


### PR DESCRIPTION
Fixes a parsing bug where conditional validations would crash on enrollments that tried to parse fundings with errors. I can't be sure this is what caused the specific user error in the ticket, but the log output from the same problem that de-railed a qa e2e test makes it seem like this should do the trick.

As far as adding a timestamp to the file name, I tried changing that in a couple places and got `cannot change _file.name because it is a read-only property`, so I'm not sure where the best place to try to add a timestamp is. Persisting to disk is handled here, but any advice on where in the code is the right place to append a timestamp?

Associated Ticket: https://github.com/ctoec/component-library/issues/121