### PR TITLE
Clean up funding spaces text in header

### DIFF
--- a/client/src/containers/Roster/Roster.scss
+++ b/client/src/containers/Roster/Roster.scss
@@ -28,12 +28,12 @@
   }
 
   .oec-accordion__content {
-    overflow-x: scroll;
+    overflow-x: visible;
   }
 
   @include at-media('desktop-lg') {
     .oec-accordion__content {
-      overflow-x: auto;
+      overflow-x: visible;
     }
   }
 }

--- a/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
+++ b/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
@@ -73,10 +73,10 @@ export const RosterSectionFundingSpacesMap: React.FC<RosterSectionFundingSpacesM
         return (
           <>
             <div key={sourceToTimes.sourceName} className="grid-row grid-gap">
-              <div className="tablet:grid-col-2 font-body-sm text-bold margin-top-1">
+              <div className="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2">
                 {sourceToTimes.sourceName.split('-')[1].trim()}
               </div>
-              <div className="tablet:grid-col-10 font-body-sm usa-hint margin-top-1">
+              <div className="tablet:grid-col-8 font-body-sm usa-hint margin-top-1">
                 {displayStr}
               </div>
             </div>

--- a/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
+++ b/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
@@ -3,7 +3,7 @@ import Divider from '@material-ui/core/Divider';
 import { Child } from '../../shared/models';
 import { getCurrentFunding } from '../../utils/models';
 
-type RosterSectionHeaderProps = {
+type RosterSectionFundingSpacesMapProps = {
   children: Child[];
   hideCapacity: boolean;
 };
@@ -20,12 +20,11 @@ type SourceToTimes = {
 };
 
 /**
- * The header for a roster section comprised of children of a single age group.
- * While it technically serves as the header, we want to be able to hide it
- * when the accordion for this content is closed, and so it will actually live
- * in the content section.
+ * The "header" area for a roster section comprised of children of a
+ * single age group. Contains information about capacity and filled
+ * spaces of each funding group included in the children.
  */
-export const RosterSectionHeader: React.FC<RosterSectionHeaderProps> = ({
+export const RosterSectionFundingSpacesMap: React.FC<RosterSectionFundingSpacesMapProps> = ({
   children,
   hideCapacity,
 }) => {
@@ -57,15 +56,15 @@ export const RosterSectionHeader: React.FC<RosterSectionHeaderProps> = ({
 
   return (
     <div>
-      {fundingSpacesMap.map((st) => {
+      {fundingSpacesMap.map((sourceToTimes) => {
         let displayStr = (
           <>
-            {st.times.map((t) => (
+            {sourceToTimes.times.map((t) => (
               <>
                 <b>{t.time}</b> {t.count}
-                {hideCapacity || st.capacity === -1
+                {hideCapacity || sourceToTimes.capacity === -1
                   ? ''
-                  : `/${st.capacity}`}{' '}
+                  : `/${sourceToTimes.capacity}`}{' '}
                 &nbsp;&nbsp;
               </>
             ))}
@@ -73,9 +72,9 @@ export const RosterSectionHeader: React.FC<RosterSectionHeaderProps> = ({
         );
         return (
           <>
-            <div key={st.sourceName} className="grid-row grid-gap">
+            <div key={sourceToTimes.sourceName} className="grid-row grid-gap">
               <div className="tablet:grid-col-2 font-body-sm text-bold margin-top-1">
-                {st.sourceName.split('-')[1].trim()}
+                {sourceToTimes.sourceName.split('-')[1].trim()}
               </div>
               <div className="tablet:grid-col-10 font-body-sm usa-hint margin-top-1">
                 {displayStr}

--- a/client/src/containers/Roster/RosterSectionHeader.tsx
+++ b/client/src/containers/Roster/RosterSectionHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import pluralize from 'pluralize';
-import { Child, FundingSpace } from '../../shared/models';
+import Divider from '@material-ui/core/Divider';
+import { Child } from '../../shared/models';
 import { getCurrentFunding } from '../../utils/models';
 
 type RosterSectionHeaderProps = {
@@ -8,48 +8,83 @@ type RosterSectionHeaderProps = {
   hideCapacity: boolean;
 };
 
+type TimeAndCount = {
+  time: string;
+  count: number;
+};
+
+type SourceToTimes = {
+  sourceName: string;
+  capacity: number;
+  times: TimeAndCount[];
+};
+
 /**
  * The header for a roster section comprised of children of a single age group.
- * Header contains total child count and information about funding space utilization
- * for the given age group.
+ * While it technically serves as the header, we want to be able to hide it
+ * when the accordion for this content is closed, and so it will actually live
+ * in the content section.
  */
 export const RosterSectionHeader: React.FC<RosterSectionHeaderProps> = ({
   children,
   hideCapacity,
 }) => {
-  const fundingSpaceCounts: {
-    fundingSpace: FundingSpace;
-    count: number;
-  }[] = [];
-  children.reduce((_counts, _child) => {
-    const fundingSpace = getCurrentFunding({ child: _child })?.fundingSpace;
+  const fundingSpacesMap: SourceToTimes[] = [];
+  children.forEach((c) => {
+    const fundingSpace = getCurrentFunding({ child: c })?.fundingSpace;
     if (fundingSpace) {
-      const entry = _counts.find((e) => e.fundingSpace.id === fundingSpace.id);
-      if (entry) {
-        entry.count += 1;
-      } else {
-        _counts.push({ fundingSpace, count: 1 });
+      let sourceMatch = fundingSpacesMap.find(
+        (fs) => fs.sourceName === fundingSpace.source
+      );
+      if (!sourceMatch) {
+        sourceMatch = {
+          sourceName: fundingSpace.source,
+          capacity: fundingSpace.capacity,
+          times: [],
+        } as SourceToTimes;
+        fundingSpacesMap.push(sourceMatch);
       }
+      let timeMatch = sourceMatch.times.find(
+        (t) => t.time === fundingSpace.time
+      );
+      if (!timeMatch) {
+        timeMatch = { time: fundingSpace.time, count: 0 } as TimeAndCount;
+        sourceMatch.times.push(timeMatch);
+      }
+      timeMatch.count += 1;
     }
-
-    return _counts;
-  }, fundingSpaceCounts);
+  });
 
   return (
-    <div className="display-flex flex-wrap">
-      {fundingSpaceCounts.map(({ fundingSpace, count }) => {
-        let displayStr = `${fundingSpace.source} ${fundingSpace.time} - ${count}`;
-        const _hideCapacity = hideCapacity || fundingSpace.capacity === -1;
-        displayStr += _hideCapacity
-          ? ` ${pluralize('space', count)} filled`
-          : `/${fundingSpace.capacity}`;
+    <div>
+      {fundingSpacesMap.map((st) => {
+        let displayStr = (
+          <>
+            {st.times.map((t) => (
+              <>
+                <b>{t.time}</b> {t.count}
+                {hideCapacity || st.capacity === -1
+                  ? ''
+                  : `/${st.capacity}`}{' '}
+                &nbsp;&nbsp;
+              </>
+            ))}
+          </>
+        );
         return (
-          <div
-            key={fundingSpace.id}
-            className="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-          >
-            {displayStr}
-          </div>
+          <>
+            <div key={st.sourceName} className="grid-row grid-gap">
+              <div className="tablet:grid-col-2 font-body-sm text-bold margin-top-1">
+                {st.sourceName.split('-')[1].trim()}
+              </div>
+              <div className="tablet:grid-col-10 font-body-sm usa-hint margin-top-1">
+                {displayStr}
+              </div>
+            </div>
+            <div className="margin-top-1 margin-bottom-1">
+              <Divider />
+            </div>
+          </>
         );
       })}
     </div>

--- a/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -317,12 +317,12 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Child Day Care
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Full-day
@@ -341,12 +341,12 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Priority School Readiness
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Full-time
@@ -840,12 +840,12 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Child Day Care
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Extended-day
@@ -1604,12 +1604,12 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Child Day Care
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Full-day
@@ -1628,12 +1628,12 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Priority School Readiness
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Full-time
@@ -2081,12 +2081,12 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Child Day Care
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Extended-day
@@ -2733,12 +2733,12 @@ exports[`Roster matches snapshot for site level user 1`] = `
                 class="grid-row grid-gap"
               >
                 <div
-                  class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                  class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                 >
                   Child Day Care
                 </div>
                 <div
-                  class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                  class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                 >
                   <b>
                     Full-day
@@ -2757,12 +2757,12 @@ exports[`Roster matches snapshot for site level user 1`] = `
                 class="grid-row grid-gap"
               >
                 <div
-                  class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                  class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                 >
                   Priority School Readiness
                 </div>
                 <div
-                  class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                  class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                 >
                   <b>
                     Full-time
@@ -3210,12 +3210,12 @@ exports[`Roster matches snapshot for site level user 1`] = `
                 class="grid-row grid-gap"
               >
                 <div
-                  class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                  class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                 >
                   Child Day Care
                 </div>
                 <div
-                  class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                  class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                 >
                   <b>
                     Extended-day
@@ -3923,12 +3923,12 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Child Day Care
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Full-day
@@ -3947,12 +3947,12 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Priority School Readiness
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Full-time
@@ -4400,12 +4400,12 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                     class="grid-row grid-gap"
                   >
                     <div
-                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                      class="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2"
                     >
                       Child Day Care
                     </div>
                     <div
-                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                      class="tablet:grid-col-8 font-body-sm usa-hint margin-top-1"
                     >
                       <b>
                         Extended-day

--- a/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -274,20 +274,6 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                         2 children 
                       </span>
                     </h3>
-                    <div
-                      class="display-flex flex-wrap"
-                    >
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        CDC - Child Day Care Full-day - 1/3
-                      </div>
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        PSR - Priority School Readiness Full-time - 1/5
-                      </div>
-                    </div>
                   </div>
                   <div
                     class="oec-accordion__heading-expand"
@@ -326,6 +312,56 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                 class="oec-accordion__content"
                 id="Infant/toddler"
               >
+                <div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Child Day Care
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Full-day
+                      </b>
+                       1/3   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Priority School Readiness
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Full-time
+                      </b>
+                       1/5   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                </div>
                 <table
                   class="oec-table margin-bottom-4"
                   id="roster-table-Infant/toddler"
@@ -761,15 +797,6 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                         1 child 
                       </span>
                     </h3>
-                    <div
-                      class="display-flex flex-wrap"
-                    >
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        CDC - Child Day Care Extended-day - 1/10
-                      </div>
-                    </div>
                   </div>
                   <div
                     class="oec-accordion__heading-expand"
@@ -808,6 +835,32 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                 class="oec-accordion__content"
                 id="Preschool"
               >
+                <div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Child Day Care
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Extended-day
+                      </b>
+                       1/10   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                </div>
                 <table
                   class="oec-table margin-bottom-4"
                   id="roster-table-Preschool"
@@ -1508,20 +1561,6 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                         2 children 
                       </span>
                     </h3>
-                    <div
-                      class="display-flex flex-wrap"
-                    >
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        CDC - Child Day Care Full-day - 1/3
-                      </div>
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        PSR - Priority School Readiness Full-time - 1/5
-                      </div>
-                    </div>
                   </div>
                   <div
                     class="oec-accordion__heading-expand"
@@ -1560,6 +1599,56 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                 class="oec-accordion__content"
                 id="Infant/toddler"
               >
+                <div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Child Day Care
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Full-day
+                      </b>
+                       1/3   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Priority School Readiness
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Full-time
+                      </b>
+                       1/5   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                </div>
                 <table
                   class="oec-table margin-bottom-4"
                   id="roster-table-Infant/toddler"
@@ -1949,15 +2038,6 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                         1 child 
                       </span>
                     </h3>
-                    <div
-                      class="display-flex flex-wrap"
-                    >
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        CDC - Child Day Care Extended-day - 1/10
-                      </div>
-                    </div>
                   </div>
                   <div
                     class="oec-accordion__heading-expand"
@@ -1996,6 +2076,32 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                 class="oec-accordion__content"
                 id="Preschool"
               >
+                <div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Child Day Care
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Extended-day
+                      </b>
+                       1/10   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                </div>
                 <table
                   class="oec-table margin-bottom-4"
                   id="roster-table-Preschool"
@@ -2584,20 +2690,6 @@ exports[`Roster matches snapshot for site level user 1`] = `
                     2 children 
                   </span>
                 </h2>
-                <div
-                  class="display-flex flex-wrap"
-                >
-                  <div
-                    class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                  >
-                    CDC - Child Day Care Full-day - 1 space filled
-                  </div>
-                  <div
-                    class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                  >
-                    PSR - Priority School Readiness Full-time - 1 space filled
-                  </div>
-                </div>
               </div>
               <div
                 class="oec-accordion__heading-expand"
@@ -2636,6 +2728,56 @@ exports[`Roster matches snapshot for site level user 1`] = `
             class="oec-accordion__content"
             id="Infant/toddler"
           >
+            <div>
+              <div
+                class="grid-row grid-gap"
+              >
+                <div
+                  class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                >
+                  Child Day Care
+                </div>
+                <div
+                  class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                >
+                  <b>
+                    Full-day
+                  </b>
+                   1   
+                </div>
+              </div>
+              <div
+                class="margin-top-1 margin-bottom-1"
+              >
+                <hr
+                  class="MuiDivider-root"
+                />
+              </div>
+              <div
+                class="grid-row grid-gap"
+              >
+                <div
+                  class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                >
+                  Priority School Readiness
+                </div>
+                <div
+                  class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                >
+                  <b>
+                    Full-time
+                  </b>
+                   1   
+                </div>
+              </div>
+              <div
+                class="margin-top-1 margin-bottom-1"
+              >
+                <hr
+                  class="MuiDivider-root"
+                />
+              </div>
+            </div>
             <table
               class="oec-table margin-bottom-4"
               id="roster-table-Infant/toddler"
@@ -3025,15 +3167,6 @@ exports[`Roster matches snapshot for site level user 1`] = `
                     1 child 
                   </span>
                 </h2>
-                <div
-                  class="display-flex flex-wrap"
-                >
-                  <div
-                    class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                  >
-                    CDC - Child Day Care Extended-day - 1 space filled
-                  </div>
-                </div>
               </div>
               <div
                 class="oec-accordion__heading-expand"
@@ -3072,6 +3205,32 @@ exports[`Roster matches snapshot for site level user 1`] = `
             class="oec-accordion__content"
             id="Preschool"
           >
+            <div>
+              <div
+                class="grid-row grid-gap"
+              >
+                <div
+                  class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                >
+                  Child Day Care
+                </div>
+                <div
+                  class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                >
+                  <b>
+                    Extended-day
+                  </b>
+                   1   
+                </div>
+              </div>
+              <div
+                class="margin-top-1 margin-bottom-1"
+              >
+                <hr
+                  class="MuiDivider-root"
+                />
+              </div>
+            </div>
             <table
               class="oec-table margin-bottom-4"
               id="roster-table-Preschool"
@@ -3721,20 +3880,6 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                         2 children 
                       </span>
                     </h3>
-                    <div
-                      class="display-flex flex-wrap"
-                    >
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        CDC - Child Day Care Full-day - 1/3
-                      </div>
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        PSR - Priority School Readiness Full-time - 1/5
-                      </div>
-                    </div>
                   </div>
                   <div
                     class="oec-accordion__heading-expand"
@@ -3773,6 +3918,56 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                 class="oec-accordion__content"
                 id="Infant/toddler"
               >
+                <div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Child Day Care
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Full-day
+                      </b>
+                       1/3   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Priority School Readiness
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Full-time
+                      </b>
+                       1/5   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                </div>
                 <table
                   class="oec-table margin-bottom-4"
                   id="roster-table-Infant/toddler"
@@ -4162,15 +4357,6 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                         1 child 
                       </span>
                     </h3>
-                    <div
-                      class="display-flex flex-wrap"
-                    >
-                      <div
-                        class="margin-top-2 margin-right-2 font-body-sm text-base-darker text-no-wrap"
-                      >
-                        CDC - Child Day Care Extended-day - 1/10
-                      </div>
-                    </div>
                   </div>
                   <div
                     class="oec-accordion__heading-expand"
@@ -4209,6 +4395,32 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                 class="oec-accordion__content"
                 id="Preschool"
               >
+                <div>
+                  <div
+                    class="grid-row grid-gap"
+                  >
+                    <div
+                      class="tablet:grid-col-2 font-body-sm text-bold margin-top-1"
+                    >
+                      Child Day Care
+                    </div>
+                    <div
+                      class="tablet:grid-col-10 font-body-sm usa-hint margin-top-1"
+                    >
+                      <b>
+                        Extended-day
+                      </b>
+                       1/10   
+                    </div>
+                  </div>
+                  <div
+                    class="margin-top-1 margin-bottom-1"
+                  >
+                    <hr
+                      class="MuiDivider-root"
+                    />
+                  </div>
+                </div>
                 <table
                   class="oec-table margin-bottom-4"
                   id="roster-table-Preschool"

--- a/client/src/containers/Roster/rosterUtils/getAccordionItems.tsx
+++ b/client/src/containers/Roster/rosterUtils/getAccordionItems.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import pluralize from 'pluralize';
 import { ErrorBoundary, InlineIcon, Table } from '@ctoec/component-library';
 import { Child } from '../../../shared/models';
-import { RosterSectionHeader } from '../RosterSectionHeader';
+import { RosterSectionFundingSpacesMap } from '../RosterSectionFundingSpacesMap';
 import { ColumnNames, tableColumns } from '../tableColumns';
 import { AccordionItemProps } from '@ctoec/component-library/dist/components/Accordion/AccordionItem';
 import { defaultErrorBoundaryProps } from '../../../utils/defaultErrorBoundaryProps';
@@ -68,7 +68,7 @@ export function getAccordionItems(
       content: (
         <>
           <ErrorBoundary alertProps={{ ...defaultErrorBoundaryProps }}>
-            <RosterSectionHeader
+            <RosterSectionFundingSpacesMap
               children={ageGroupChildren}
               hideCapacity={opts.hideCapacity}
             />

--- a/client/src/containers/Roster/rosterUtils/getAccordionItems.tsx
+++ b/client/src/containers/Roster/rosterUtils/getAccordionItems.tsx
@@ -55,12 +55,6 @@ export function getAccordionItems(
           )}
         </>
       ),
-      headerContent: (
-        <RosterSectionHeader
-          children={ageGroupChildren}
-          hideCapacity={opts.hideCapacity}
-        />
-      ),
       expandText: (
         <>
           Show<span className="usa-sr-only">{` ${ageGroup} roster`}</span>
@@ -72,17 +66,23 @@ export function getAccordionItems(
         </>
       ),
       content: (
-        <ErrorBoundary alertProps={{ ...defaultErrorBoundaryProps }}>
-          <Table<Child>
-            className="margin-bottom-4"
-            id={`roster-table-${ageGroup}`}
-            rowKey={(row) => row?.id}
-            data={ageGroupChildren}
-            columns={tableColumns(excludeColumns)}
-            defaultSortColumn={0}
-            defaultSortOrder="ascending"
-          />
-        </ErrorBoundary>
+        <>
+          <ErrorBoundary alertProps={{ ...defaultErrorBoundaryProps }}>
+            <RosterSectionHeader
+              children={ageGroupChildren}
+              hideCapacity={opts.hideCapacity}
+            />
+            <Table<Child>
+              className="margin-bottom-4"
+              id={`roster-table-${ageGroup}`}
+              rowKey={(row) => row?.id}
+              data={ageGroupChildren}
+              columns={tableColumns(excludeColumns)}
+              defaultSortColumn={0}
+              defaultSortOrder="ascending"
+            />
+          </ErrorBoundary>
+        </>
       ),
       isExpanded: ageGroupChildren.length <= MAX_LENGTH_EXPANDED,
     }));


### PR DESCRIPTION
## Background
The funding space headers of each age group in the roster accordion are textually cluttered, making it hard to see at a glance what the filled status of each funding space is. This PR cleans up those headers to more succinctly display capacity information.

## GitHub Issue
https://github.com/ctoec/data-collection/issues/671

## Validation Plan
I've uploaded several different files featuring all the different funding spaces and have checked that names and counts get correctly displayed. Also tested that showing and hiding an accordion group hides the space totals info.

## Automated Testing
- [ ] All unit tests are passing.
- [ ] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset. (not applicable)
- [ ] If applicable, e2e tests have been added to cover this changeset. (not applicable)

## Additional Context
Since the AC of the ticket asked for the space totals information to be hidden when the age group accordion is collapsed, I've moved the "header" portion into the content itself. This visually looks almost identical to me, but it seemed like the best way for the single Show/Hide button in the Accordion to control both the children roster and the space totals text.