### PR TITLE
Address Funding Space Overlap Bug

### DIFF
--- a/client/src/containers/Roster/Roster.tsx
+++ b/client/src/containers/Roster/Roster.tsx
@@ -248,6 +248,7 @@ const Roster: React.FC = () => {
 
   return (
     <>
+    <ErrorBoundary alertProps={defaultErrorBoundaryProps}>
       <div className="Roster grid-container">
         <BackButton
           location={
@@ -316,6 +317,7 @@ const Roster: React.FC = () => {
           )}
         </FixedBottomBar>
       )}
+      </ErrorBoundary>
     </>
   );
 };

--- a/client/src/containers/Roster/Roster.tsx
+++ b/client/src/containers/Roster/Roster.tsx
@@ -79,12 +79,17 @@ const Roster: React.FC = () => {
     if (query) setRosterQuery(query);
   }, [query?.organization, query?.month]);
 
-  // TODO: handle fetching error
-  const {
+  let {
     children: allChildren,
     stillFetching: loading,
-    error: rosterError
+    error: fetchRosterError
   } = usePaginatedChildData(query);
+
+  if (fetchRosterError) {
+    loading = false;
+    throw fetchRosterError;
+  }
+
   const {
     active: activeChildren,
     withdrawn: withdrawnChildren,

--- a/client/src/containers/Roster/Roster.tsx
+++ b/client/src/containers/Roster/Roster.tsx
@@ -82,11 +82,10 @@ const Roster: React.FC = () => {
   let {
     children: allChildren,
     stillFetching: loading,
-    error: fetchRosterError
+    error: fetchRosterError,
   } = usePaginatedChildData(query);
 
   if (fetchRosterError) {
-    loading = false;
     throw fetchRosterError;
   }
 
@@ -248,7 +247,6 @@ const Roster: React.FC = () => {
 
   return (
     <>
-    <ErrorBoundary alertProps={defaultErrorBoundaryProps}>
       <div className="Roster grid-container">
         <BackButton
           location={
@@ -317,7 +315,6 @@ const Roster: React.FC = () => {
           )}
         </FixedBottomBar>
       )}
-      </ErrorBoundary>
     </>
   );
 };

--- a/client/src/containers/Roster/Roster.tsx
+++ b/client/src/containers/Roster/Roster.tsx
@@ -83,6 +83,7 @@ const Roster: React.FC = () => {
   const {
     children: allChildren,
     stillFetching: loading,
+    error: rosterError
   } = usePaginatedChildData(query);
   const {
     active: activeChildren,

--- a/client/src/containers/Roster/hooks/usePaginatedChildData.tsx
+++ b/client/src/containers/Roster/hooks/usePaginatedChildData.tsx
@@ -38,6 +38,10 @@ export const usePaginatedChildData = (query: RosterQueryParams) => {
       : null;
   });
 
+  if (error) {
+    stillFetching = false;
+  }
+
   // Trigger next fetch if
   // - we've completed the first fetch (childrenArrays != undefined)
   // - we've completed our most recently triggered fetch (childrenArrays.length == size)

--- a/src/controllers/children/get.ts
+++ b/src/controllers/children/get.ts
@@ -44,7 +44,6 @@ export const getChildren = async (
     take?: number;
   } = {}
 ) => {
-  throw new Error('WHOOPS');
 
   let {
     organizationIds,

--- a/src/controllers/children/get.ts
+++ b/src/controllers/children/get.ts
@@ -44,6 +44,8 @@ export const getChildren = async (
     take?: number;
   } = {}
 ) => {
+  throw new Error('WHOOPS');
+
   let {
     organizationIds,
     missingInfoOnly,

--- a/src/entity/decorators/Funding/fundingOverlapValidation.ts
+++ b/src/entity/decorators/Funding/fundingOverlapValidation.ts
@@ -18,7 +18,6 @@ export function FundingDoesNotOverlap(
       constraints: [{ fundingPeriod: fundingPeriodOverlap }],
       validator: {
         validate(_, { object: funding }) {
-          console.error('hey look things happened');
           const allFundings = (funding as any).allFundings;
           if (!allFundings) return true;
 
@@ -42,10 +41,8 @@ export function FundingDoesNotOverlap(
           let overlap = false;
           allExceptThisFunding.forEach((_funding) => {
             const _firstPeriod = _funding.firstReportingPeriod;
-            console.error(`Fundingggggggggg: FUNDING ${_funding.id}`)
 
             if (!_firstPeriod) {
-              console.error(`WOOOOOOOO, NO FIRST PERIOD FOUND FOR ${_funding.id}`)
               return;
             }
 

--- a/src/entity/decorators/Funding/fundingOverlapValidation.ts
+++ b/src/entity/decorators/Funding/fundingOverlapValidation.ts
@@ -18,6 +18,7 @@ export function FundingDoesNotOverlap(
       constraints: [{ fundingPeriod: fundingPeriodOverlap }],
       validator: {
         validate(_, { object: funding }) {
+          console.error('hey look things happened');
           const allFundings = (funding as any).allFundings;
           if (!allFundings) return true;
 
@@ -41,10 +42,10 @@ export function FundingDoesNotOverlap(
           let overlap = false;
           allExceptThisFunding.forEach((_funding) => {
             const _firstPeriod = _funding.firstReportingPeriod;
-            console.log(`Fundingggggggggg: FUNDING ${_funding.id}`)
+            console.error(`Fundingggggggggg: FUNDING ${_funding.id}`)
 
             if (!_firstPeriod) {
-              console.log(`WOOOOOOOO, NO FIRST PERIOD FOUND FOR ${_funding.id}`)
+              console.error(`WOOOOOOOO, NO FIRST PERIOD FOUND FOR ${_funding.id}`)
               return;
             }
 

--- a/src/entity/decorators/Funding/fundingOverlapValidation.ts
+++ b/src/entity/decorators/Funding/fundingOverlapValidation.ts
@@ -43,7 +43,6 @@ export function FundingDoesNotOverlap(
             const _firstPeriod = _funding.firstReportingPeriod;
 
             if (!_firstPeriod) {
-              console.error('AH HEY LOOK AT DIS', _funding);
               return;
             }
 

--- a/src/entity/decorators/Funding/fundingOverlapValidation.ts
+++ b/src/entity/decorators/Funding/fundingOverlapValidation.ts
@@ -42,6 +42,10 @@ export function FundingDoesNotOverlap(
           allExceptThisFunding.forEach((_funding) => {
             const _firstPeriod = _funding.firstReportingPeriod;
 
+            if (!_firstPeriod) {
+              return;
+            }
+
             if (
               _firstPeriod.periodStart.isSame(validatingFirstPeriod.periodStart)
             ) {

--- a/src/entity/decorators/Funding/fundingOverlapValidation.ts
+++ b/src/entity/decorators/Funding/fundingOverlapValidation.ts
@@ -43,6 +43,7 @@ export function FundingDoesNotOverlap(
             const _firstPeriod = _funding.firstReportingPeriod;
 
             if (!_firstPeriod) {
+              console.error('AH HEY LOOK AT DIS', _funding);
               return;
             }
 

--- a/src/entity/decorators/Funding/fundingOverlapValidation.ts
+++ b/src/entity/decorators/Funding/fundingOverlapValidation.ts
@@ -41,8 +41,10 @@ export function FundingDoesNotOverlap(
           let overlap = false;
           allExceptThisFunding.forEach((_funding) => {
             const _firstPeriod = _funding.firstReportingPeriod;
+            console.log(`Fundingggggggggg: FUNDING ${_funding.id}`)
 
             if (!_firstPeriod) {
+              console.log(`WOOOOOOOO, NO FIRST PERIOD FOUND FOR ${_funding.id}`)
               return;
             }
 


### PR DESCRIPTION
## Background
Our funding space overlap validator currently breaks when comparing a given funding with all the other fundings within an organization and **at least one** of those fundings is missing a reporting period start date.  This PR addresses that.

## GitHub Issue
- #1137

## Associated PRs
N/A

## Validation Plan
- [x] Funding Space Overlap validator doesn't include fundings without a reporting period start date
- [x] Rosters containing enrollments with fundings **without** a starting reporting period can be loaded successfully
- [x] Funding Space Overlap validator still functions as expected

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.

## Additional Context
N/A