### PR TITLE
605 first reporting period

### DIFF
--- a/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
+++ b/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
@@ -106,7 +106,7 @@ export const NewFundingField = <
           id,
           value: id,
           text: fundingSource,
-          onChange: () => { },
+          onChange: () => {},
           expansion: (
             <>
               <ContractSpaceField<T>

--- a/client/src/containers/CreateRecord/listSteps.tsx
+++ b/client/src/containers/CreateRecord/listSteps.tsx
@@ -13,7 +13,6 @@ import {
   SECTION_KEYS,
   formSections,
 } from '../../components/Forms/formSections';
-import { UndefinableBoolean } from '../../shared/models';
 
 export const newForms = [
   { key: SECTION_KEYS.IDENT, form: ChildIdentifiersForm },

--- a/e2e-tests/utils/newChildInput.js
+++ b/e2e-tests/utils/newChildInput.js
@@ -122,7 +122,7 @@ module.exports = {
       clickLabel: true,
     },
     {
-      id: 'CDC---Child-Day-Care',
+      id: 'CDC-Child-Day-Care',
       clickLabel: true,
     },
     {

--- a/e2e-tests/utils/newChildInput.js
+++ b/e2e-tests/utils/newChildInput.js
@@ -122,7 +122,7 @@ module.exports = {
       clickLabel: true,
     },
     {
-      id: 'CDC-Child-Day-Care',
+      id: 'CDC-ChildDayCare',
       clickLabel: true,
     },
     {

--- a/src/controllers/enrollments.ts
+++ b/src/controllers/enrollments.ts
@@ -29,7 +29,7 @@ export const getFunding = async (
   // To assert that the user has access to the enrollment
   await getEnrollment(enrollmentId, user);
   const funding = await getManager().findOne(Funding, fundingId, {
-    where: { enrollmentId: enrollmentId },
+    where: { enrollmentId },
   });
 
   if (!funding) throw new NotFoundError();


### PR DESCRIPTION
## Background
Fixes bug described in #605 by adding or modifying fundings in enrollment edit endpoint. Fixes bug where existing funding source was not selected on page refresh in radio button group.

## GitHub Issue
#605 
Also addresses #1133 

## Associated PRs
-

## Validation Plan
Follow steps as described in 605 or, to shortcut this and not go through the entire create child flow, click on a child with incomplete information and replace "edit" with "create" in the URL.

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset.
- [ ] If applicable, e2e tests have been added to cover this changeset.

## Additional Context
-