### PR TITLE
Fix up batch edit and funding cards

### DIFF
--- a/client/src/containers/BatchEdit/BatchEdit.tsx
+++ b/client/src/containers/BatchEdit/BatchEdit.tsx
@@ -92,7 +92,8 @@ const BatchEdit: React.FC = () => {
       <div className="grid-container">
         <BatchEditItemContent
           childId={childId}
-          moveNextRecord={() => history.goBack()}
+          moveNextRecord={() => {}}
+          isSingleRecord={true}
         />
       </div>
     );

--- a/client/src/containers/BatchEdit/BatchEditItemContent.tsx
+++ b/client/src/containers/BatchEdit/BatchEditItemContent.tsx
@@ -14,7 +14,7 @@ import { useAlerts } from '../../hooks/useAlerts';
 import { hasValidationErrorForField } from '../../utils/hasValidationError';
 import { apiGet } from '../../utils/api';
 import AuthenticationContext from '../../contexts/AuthenticationContext/AuthenticationContext';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import { getCurrentEnrollment } from '../../utils/models';
 import { mutateCallback } from 'swr/dist/types';
 import RosterContext from '../../contexts/RosterContext/RosterContext';
@@ -24,16 +24,19 @@ type BatchEditItemContentProps = {
   organizationId?: string;
   moveNextRecord: (_?: Child[]) => void;
   mutate?: (_: mutateCallback<Child[]>, __: boolean) => void;
+  isSingleRecord?: boolean;
 };
 
 export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
   childId,
   moveNextRecord,
   mutate,
+  isSingleRecord,
 }) => {
   const [child, setChild] = useState<Child>();
 
   const { setAlerts } = useAlerts();
+  const history = useHistory();
 
   const [steps, setSteps] = useState<StepProps<RecordFormProps>[]>();
   const [activeStepKey, setActiveStep] = useState<string>();
@@ -42,6 +45,23 @@ export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
   const [triggerRefetchCount, setTriggerRefetchCount] = useState(0);
 
   const { updateCurrentRosterCache } = useContext(RosterContext);
+
+  // Special function for single record batch edit because we use the child's
+  // name information in an alert
+  const singleRecordSuccess = () => {
+    history.push(`/roster`, {
+      alerts: [
+        {
+          type: 'success',
+          heading: 'Changed saved!',
+          text: `${child?.firstName}'s record now has all required information.`,
+        },
+      ],
+    });
+  };
+  const afterRecordAction = isSingleRecord
+    ? singleRecordSuccess
+    : moveNextRecord;
 
   // Reset state when new child
   useEffect(() => {
@@ -68,7 +88,7 @@ export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
 
     const activeStepIdx = steps.findIndex((step) => step.key === activeStepKey);
     if (activeStepIdx === steps.length - 1) {
-      moveNextRecord(records);
+      afterRecordAction(records);
     } else {
       setActiveStep(steps[activeStepIdx + 1].key);
     }
@@ -112,7 +132,7 @@ export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
     AdditionalButton: (
       <Button
         text="Skip"
-        onClick={() => moveNextRecord()}
+        onClick={() => afterRecordAction()}
         appearance="outline"
       />
     ),

--- a/client/src/containers/BatchEdit/BatchEditItemContent.tsx
+++ b/client/src/containers/BatchEdit/BatchEditItemContent.tsx
@@ -49,12 +49,15 @@ export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
   // Special function for single record batch edit because we use the child's
   // name information in an alert
   const singleRecordSuccess = () => {
+    console.log(child?.firstName);
     history.push(`/roster`, {
       alerts: [
         {
           type: 'success',
           heading: 'Changed saved!',
-          text: `${child?.firstName}'s record now has all required information.`,
+          text: `${
+            child?.firstName ? child?.firstName : 'Child'
+          }'s record now has all required information.`,
         },
       ],
     });

--- a/client/src/containers/BatchEdit/BatchEditItemContent.tsx
+++ b/client/src/containers/BatchEdit/BatchEditItemContent.tsx
@@ -49,7 +49,6 @@ export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
   // Special function for single record batch edit because we use the child's
   // name information in an alert
   const singleRecordSuccess = () => {
-    console.log(child?.firstName);
     history.push(`/roster`, {
       alerts: [
         {

--- a/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
@@ -4,7 +4,7 @@ import { EditFundingCard } from './EditFundingCard';
 import { ChangeEnrollmentCard } from './ChangeEnrollment/Card';
 import { ChangeFundingCard } from './ChangeFunding/Card';
 import { EditEnrollmentCard } from './EditEnrollmentCard';
-import { Enrollment } from '../../../shared/models';
+import { Enrollment, Funding } from '../../../shared/models';
 import { getNextHeadingLevel, Heading } from '../../../components/Heading';
 
 export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
@@ -26,6 +26,19 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
   const pastEnrollments: Enrollment[] = currentEnrollment
     ? enrollments.filter((e) => e.id !== currentEnrollment.id)
     : enrollments;
+
+  const sortFundingsByDate = (fundings: Funding[] | undefined) => {
+    if (!fundings) return [];
+    return fundings.sort((a, b) => {
+      if (
+        a.firstReportingPeriod?.period.isSameOrBefore(
+          b.firstReportingPeriod?.period
+        )
+      )
+        return 1;
+      else return -1;
+    });
+  };
 
   const commonProps = {
     afterSaveSuccess,
@@ -53,17 +66,8 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
             enrollmentId={currentEnrollment.id}
             topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
           />
-          {currentEnrollment.fundings
-            ?.sort((a, b) => {
-              if (
-                a.firstReportingPeriod?.period.isSameOrBefore(
-                  b.firstReportingPeriod?.period
-                )
-              )
-                return 1;
-              else return -1;
-            })
-            .map((funding, idx) => (
+          {sortFundingsByDate(currentEnrollment.fundings).map(
+            (funding, idx) => (
               <EditFundingCard
                 {...commonProps}
                 key={funding.id}
@@ -72,7 +76,8 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
                 enrollmentId={currentEnrollment.id}
                 topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
               />
-            ))}
+            )
+          )}
           <ChangeFundingCard
             {...commonProps}
             enrollment={currentEnrollment}
@@ -95,25 +100,15 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
                 enrollmentId={enrollment.id}
                 topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
               />
-              {enrollment.fundings
-                ?.sort((a, b) => {
-                  if (
-                    a.firstReportingPeriod?.period.isSameOrBefore(
-                      b.firstReportingPeriod?.period
-                    )
-                  )
-                    return 1;
-                  else return -1;
-                })
-                .map((funding) => (
-                  <EditFundingCard
-                    {...commonProps}
-                    key={funding.id}
-                    fundingId={funding.id}
-                    enrollmentId={enrollment.id}
-                    topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
-                  />
-                ))}
+              {sortFundingsByDate(enrollment.fundings).map((funding) => (
+                <EditFundingCard
+                  {...commonProps}
+                  key={funding.id}
+                  fundingId={funding.id}
+                  enrollmentId={enrollment.id}
+                  topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
+                />
+              ))}
             </>
           ))}
         </>

--- a/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/Form.tsx
@@ -53,16 +53,26 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
             enrollmentId={currentEnrollment.id}
             topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
           />
-          {currentEnrollment.fundings?.map((funding) => (
-            <EditFundingCard
-              {...commonProps}
-              key={funding.id}
-              isCurrent={true}
-              fundingId={funding.id}
-              enrollmentId={currentEnrollment.id}
-              topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
-            />
-          ))}
+          {currentEnrollment.fundings
+            ?.sort((a, b) => {
+              if (
+                a.firstReportingPeriod?.period.isSameOrBefore(
+                  b.firstReportingPeriod?.period
+                )
+              )
+                return 1;
+              else return -1;
+            })
+            .map((funding, idx) => (
+              <EditFundingCard
+                {...commonProps}
+                key={funding.id}
+                isCurrent={idx === 0 ? true : false}
+                fundingId={funding.id}
+                enrollmentId={currentEnrollment.id}
+                topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
+              />
+            ))}
           <ChangeFundingCard
             {...commonProps}
             enrollment={currentEnrollment}
@@ -85,15 +95,25 @@ export const EnrollmentFundingForm: React.FC<RecordFormProps> = ({
                 enrollmentId={enrollment.id}
                 topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
               />
-              {enrollment.fundings?.map((funding) => (
-                <EditFundingCard
-                  {...commonProps}
-                  key={funding.id}
-                  fundingId={funding.id}
-                  enrollmentId={enrollment.id}
-                  topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
-                />
-              ))}
+              {enrollment.fundings
+                ?.sort((a, b) => {
+                  if (
+                    a.firstReportingPeriod?.period.isSameOrBefore(
+                      b.firstReportingPeriod?.period
+                    )
+                  )
+                    return 1;
+                  else return -1;
+                })
+                .map((funding) => (
+                  <EditFundingCard
+                    {...commonProps}
+                    key={funding.id}
+                    fundingId={funding.id}
+                    enrollmentId={enrollment.id}
+                    topHeadingLevel={getNextHeadingLevel(topHeadingLevel, 2)}
+                  />
+                ))}
             </>
           ))}
         </>


### PR DESCRIPTION
## Background
There are two quick fast follows fixes that involve tweaking up some UI aspects of the tool. This PR sorts funding cards so that the most current one is at the top, grays out the backgrounds of expired funding cards, and pushes an alert to the roster page if a user comes from a single record batch edit.

## GitHub Issue
#273 
#657 

## Validation Plan
I tested the new batch edit functionality with a variety of single record batch edits and confirmed that it works when using the traditional batch edit on multiple records. I got the correct alert state in each case.

## Automated Testing
- [x] All unit tests are passing.
- [ ] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset (not applicable).
- [ ] If applicable, e2e tests have been added to cover this changeset (not applicable).