### PR TITLE
1145 batch edit

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -36,7 +36,7 @@
     "react-router-dom": "^5.2.0",
     "react-scripts": "^3.4.4",
     "sass": "^1.27.0",
-    "swr": "^0.3.6",
+    "swr": "^0.4.2",
     "typescript": "^3.9.5",
     "uswds": "2.9.0"
   },

--- a/client/src/containers/BatchEdit/BatchEdit.tsx
+++ b/client/src/containers/BatchEdit/BatchEdit.tsx
@@ -29,21 +29,21 @@ const BatchEdit: React.FC = () => {
   const { alertElements } = useAlerts();
 
   const h1Ref = getH1RefForTitle();
-  // TODO: write wrapper for this that sets results of use authenticatedswr as a state, and takes a dep array?
   const { data: children, isValidating, mutate, error } = useAuthenticatedSWR<
     Child[]
   >(
     childId
       ? null // no need to fetch all children for single record batch edit
-      : `children?${stringify({ organizationId, 'missing-info': true })}`
+      : `children?${stringify({ organizationId, 'missing-info': true })}`,
+    {
+      revalidateOnFocus: false,
+    }
   );
   const loading = !children && !error;
   // Only children with validation errors, only set after initial fetch
   const [fixedRecordsForDisplayIds, setFixedRecordsForDisplayIds] = useState<
     string[]
   >([]);
-
-  console.log({ children, isValidating, error, fixedRecordsForDisplayIds })
 
   useEffect(() => {
     if (!isValidating && !!children) {
@@ -56,7 +56,9 @@ const BatchEdit: React.FC = () => {
   const fixedRecordsForDisplay = fixedRecordsForDisplayIds.map((id) =>
     (children || []).find((c) => c.id === id)
   ) as Child[];
-  const currentlyMissingInfoCount = fixedRecordsForDisplay.length
+  const currentlyMissingInfoCount = fixedRecordsForDisplay.filter(
+    hasValidationError
+  ).length;
 
   const [activeRecordId, setActiveRecordId] = useState<string>();
   useEffect(() => {
@@ -94,7 +96,7 @@ const BatchEdit: React.FC = () => {
       <div className="grid-container">
         <BatchEditItemContent
           childId={childId}
-          moveNextRecord={() => { }}
+          moveNextRecord={() => {}}
           isSingleRecord={true}
         />
       </div>
@@ -121,12 +123,12 @@ const BatchEdit: React.FC = () => {
                 incomplete info required to submit your data
               </>
             ) : (
-                <>
-                  {/* TODO make it possible to make this icon big */}
-                  <InlineIcon className="height-4 width-4" icon="complete" /> All
+              <>
+                {/* TODO make it possible to make this icon big */}
+                <InlineIcon className="height-4 width-4" icon="complete" /> All
                 enrollments are complete
               </>
-              )}
+            )}
           </div>
           <SideNav
             activeItemId={activeRecordId}
@@ -157,21 +159,21 @@ const BatchEdit: React.FC = () => {
                 />
               </ErrorBoundary>
             ) : (
-                <div className="margin-x-4 margin-top-4 display-flex flex-column flex-align-center">
-                  <InlineIcon icon="complete" />
-                  <p className="font-body-lg text-bold margin-y-1">
-                    All records are complete!
+              <div className="margin-x-4 margin-top-4 display-flex flex-column flex-align-center">
+                <InlineIcon icon="complete" />
+                <p className="font-body-lg text-bold margin-y-1">
+                  All records are complete!
                 </p>
-                  <Link to="/roster">
-                    <TextWithIcon
-                      text="Back to roster"
-                      iconSide="right"
-                      Icon={ArrowRight}
-                      direction="right"
-                    />
-                  </Link>
-                </div>
-              )}
+                <Link to="/roster">
+                  <TextWithIcon
+                    text="Back to roster"
+                    iconSide="right"
+                    Icon={ArrowRight}
+                    direction="right"
+                  />
+                </Link>
+              </div>
+            )}
           </SideNav>
         </ErrorBoundary>
       </LoadingWrapper>

--- a/client/src/containers/BatchEdit/BatchEdit.tsx
+++ b/client/src/containers/BatchEdit/BatchEdit.tsx
@@ -12,7 +12,7 @@ import { BackButton } from '../../components/BackButton';
 import { hasValidationError } from '../../utils/hasValidationError';
 import pluralize from 'pluralize';
 import { nameFormatter } from '../../utils/formatters';
-import { Link, useParams, useHistory, useLocation } from 'react-router-dom';
+import { Link, useParams, useLocation } from 'react-router-dom';
 import { BatchEditItemContent } from './BatchEditItemContent';
 import { Child } from '../../shared/models';
 import { getBatchEditErrorDetailsString } from './listSteps';
@@ -28,8 +28,8 @@ const BatchEdit: React.FC = () => {
   };
   const { alertElements } = useAlerts();
 
-  const history = useHistory();
   const h1Ref = getH1RefForTitle();
+  // TODO: write wrapper for this that sets results of use authenticatedswr as a state, and takes a dep array?
   const { data: children, isValidating, mutate, error } = useAuthenticatedSWR<
     Child[]
   >(
@@ -38,9 +38,13 @@ const BatchEdit: React.FC = () => {
       : `children?${stringify({ organizationId, 'missing-info': true })}`
   );
   const loading = !children && !error;
+  // Only children with validation errors, only set after initial fetch
   const [fixedRecordsForDisplayIds, setFixedRecordsForDisplayIds] = useState<
     string[]
   >([]);
+
+  console.log({ children, isValidating, error, fixedRecordsForDisplayIds })
+
   useEffect(() => {
     if (!isValidating && !!children) {
       setFixedRecordsForDisplayIds(
@@ -52,9 +56,7 @@ const BatchEdit: React.FC = () => {
   const fixedRecordsForDisplay = fixedRecordsForDisplayIds.map((id) =>
     (children || []).find((c) => c.id === id)
   ) as Child[];
-  const currentlyMissingInfoCount = fixedRecordsForDisplay.filter(
-    hasValidationError
-  ).length;
+  const currentlyMissingInfoCount = fixedRecordsForDisplay.length
 
   const [activeRecordId, setActiveRecordId] = useState<string>();
   useEffect(() => {
@@ -92,7 +94,7 @@ const BatchEdit: React.FC = () => {
       <div className="grid-container">
         <BatchEditItemContent
           childId={childId}
-          moveNextRecord={() => {}}
+          moveNextRecord={() => { }}
           isSingleRecord={true}
         />
       </div>
@@ -119,12 +121,12 @@ const BatchEdit: React.FC = () => {
                 incomplete info required to submit your data
               </>
             ) : (
-              <>
-                {/* TODO make it possible to make this icon big */}
-                <InlineIcon className="height-4 width-4" icon="complete" /> All
+                <>
+                  {/* TODO make it possible to make this icon big */}
+                  <InlineIcon className="height-4 width-4" icon="complete" /> All
                 enrollments are complete
               </>
-            )}
+              )}
           </div>
           <SideNav
             activeItemId={activeRecordId}
@@ -155,21 +157,21 @@ const BatchEdit: React.FC = () => {
                 />
               </ErrorBoundary>
             ) : (
-              <div className="margin-x-4 margin-top-4 display-flex flex-column flex-align-center">
-                <InlineIcon icon="complete" />
-                <p className="font-body-lg text-bold margin-y-1">
-                  All records are complete!
+                <div className="margin-x-4 margin-top-4 display-flex flex-column flex-align-center">
+                  <InlineIcon icon="complete" />
+                  <p className="font-body-lg text-bold margin-y-1">
+                    All records are complete!
                 </p>
-                <Link to="/roster">
-                  <TextWithIcon
-                    text="Back to roster"
-                    iconSide="right"
-                    Icon={ArrowRight}
-                    direction="right"
-                  />
-                </Link>
-              </div>
-            )}
+                  <Link to="/roster">
+                    <TextWithIcon
+                      text="Back to roster"
+                      iconSide="right"
+                      Icon={ArrowRight}
+                      direction="right"
+                    />
+                  </Link>
+                </div>
+              )}
           </SideNav>
         </ErrorBoundary>
       </LoadingWrapper>

--- a/client/src/containers/BatchEdit/BatchEditItemContent.tsx
+++ b/client/src/containers/BatchEdit/BatchEditItemContent.tsx
@@ -105,7 +105,7 @@ export const BatchEditItemContent: React.FC<BatchEditItemContentProps> = ({
         setChild(updatedChild);
         let updatedChildren: Child[] = [];
         if (mutate) {
-          mutate((children: Child[]) => {
+          mutate((children?: Child[]) => {
             if (children) {
               updatedChildren = [...children];
               const idx = updatedChildren.findIndex((c) => c.id === childId);

--- a/client/src/hooks/useAuthenticatedSWR.ts
+++ b/client/src/hooks/useAuthenticatedSWR.ts
@@ -4,6 +4,7 @@ import useSWR, {
   responseInterface,
   useSWRInfinite,
   SWRInfiniteResponseInterface,
+  ConfigInterface,
 } from 'swr';
 
 /**
@@ -13,13 +14,15 @@ import useSWR, {
  * Additionally, enables typing casting of the response data from useSWR.
  * @param path
  */
-export function useAuthenticatedSWR<T>(path: string | null) {
-  console.log('auth swr')
+export function useAuthenticatedSWR<T>(
+  path: string | null,
+  config?: ConfigInterface
+) {
   const { accessToken } = useContext(AuthenticationContext);
-  return useSWR(!path ? null : [path, accessToken]) as responseInterface<
-    T,
-    string
-  >;
+  return useSWR(
+    !path ? null : [path, accessToken],
+    config
+  ) as responseInterface<T, string>;
 }
 
 /**

--- a/client/src/hooks/useAuthenticatedSWR.ts
+++ b/client/src/hooks/useAuthenticatedSWR.ts
@@ -14,6 +14,7 @@ import useSWR, {
  * @param path
  */
 export function useAuthenticatedSWR<T>(path: string | null) {
+  console.log('auth swr')
   const { accessToken } = useContext(AuthenticationContext);
   return useSWR(!path ? null : [path, accessToken]) as responseInterface<
     T,

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11585,10 +11585,10 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
-swr@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-0.3.6.tgz#b1d59439e5114fdf95bb408e1c628ff48f967aac"
-  integrity sha512-LHbX9vVQSW8Kgyr86zz2fVVKmmT13qxB61uXuUAg6NT4cGu6afzAzT2SVCGEh8pJAD2o8NTZMgclIUxIAbvk7Q==
+swr@^0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-0.4.2.tgz#4a9ed5e9948088af145c79d716d294cb99712a29"
+  integrity sha512-SKGxcAfyijj/lE5ja5zVMDqJNudASH3WZPRUakDVOePTM18FnsXgugndjl9BSRwj+jokFCulMDe7F2pQL+VhEw==
   dependencies:
     dequal "2.0.2"
 


### PR DESCRIPTION
## Background
Use swr config option to not revalidate on window focus so that we don't re-fetch children with missing info. Re-fetching was preventing us from displaying completed records in side nav.

## GitHub Issue
#1145 

## Associated PRs

## Validation Plan
Follow detailed steps in ticket

## Automated Testing
- [ ] All unit tests are passing.
- [ ] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset.
- [ ] If applicable, e2e tests have been added to cover this changeset.

## Additional Context
