### PR TITLE
Ignore Funding Space ID in test env seeders

### DIFF
--- a/src/data/fake/initialize.ts
+++ b/src/data/fake/initialize.ts
@@ -1,4 +1,5 @@
 import { EntityManager, getManager } from 'typeorm';
+import { omit } from 'underscore';
 import {
   Organization,
   Site,
@@ -112,7 +113,7 @@ export const initialize = async () => {
       if (!(await getManager().find(FundingSpace)).length) {
         const fundingSpacesToAdd = await Promise.all(
           getFakeFundingSpaces(organization).map((fs) => {
-            return getManager().create(FundingSpace, fs);
+            return getManager().create(FundingSpace, omit(fs, 'id'));
           })
         );
         await getManager().save(fundingSpacesToAdd);


### PR DESCRIPTION
## Background
Ignore the funding space ID value when inserting seed data so we don't attempt to insert ID values that have since been added and removed (because we auto-increment).

## GitHub Issue
- N/A

## Associated PRs
- N/A

## Validation Plan
- [x] Deploy to QA and confirm seeder completes successfully.

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.

## Additional Context
- N/A