### PR TITLE
Forcibly trim funding source acronyms from funding sources

### DIFF
--- a/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
+++ b/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
@@ -19,6 +19,7 @@ import { useAuthenticatedSWR } from '../../../../hooks/useAuthenticatedSWR';
 import { getValidationStatusForFields } from '../../../../utils/getValidationStatus';
 import { HideErrorProps } from '../../types';
 import { getCurrentFunding } from '../../../../utils/models';
+import { getStrippedFundingSourceName } from '../../../../containers/Home/utils/getFundingSpaceDisplayName';
 
 type FundingFieldProps<T> = {
   fundingAccessor?: (_: TObjectDriller<T>) => TObjectDriller<Funding>;
@@ -109,7 +110,7 @@ export const NewFundingField = <
         return {
           id,
           value: id,
-          text: fundingSource.split('-')[1].trim(),
+          text: getStrippedFundingSourceName(fundingSource),
           onChange: () => {},
           expansion: (
             <>

--- a/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
+++ b/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
@@ -109,7 +109,7 @@ export const NewFundingField = <
         return {
           id,
           value: id,
-          text: fundingSource,
+          text: fundingSource.split('-')[0].trim(),
           onChange: () => {},
           expansion: (
             <>

--- a/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
+++ b/client/src/components/Forms/Enrollment/Fields/NewFunding.tsx
@@ -109,7 +109,7 @@ export const NewFundingField = <
         return {
           id,
           value: id,
-          text: fundingSource.split('-')[0].trim(),
+          text: fundingSource.split('-')[1].trim(),
           onChange: () => {},
           expansion: (
             <>

--- a/client/src/containers/EditRecord/EnrollmentFunding/EditFundingCard.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/EditFundingCard.tsx
@@ -121,7 +121,7 @@ export const EditFundingCard: React.FC<EditFundingCardProps> = ({
           {funding.fundingSpace ? (
             <Tag
               className="margin-top-0"
-              text={funding.fundingSpace.source.split('-')[0].trim()}
+              text={funding.fundingSpace.source.split('-')[1].trim()}
             />
           ) : (
             InlineIcon({ icon: 'incomplete' })

--- a/client/src/containers/EditRecord/EnrollmentFunding/EditFundingCard.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/EditFundingCard.tsx
@@ -18,6 +18,7 @@ import { RecordFormProps } from '../../../components/Forms';
 import { hasValidationErrorForField } from '../../../utils/hasValidationError';
 import { HeadingLevel } from '../../../components/Heading';
 import { fundingHasNoInformation } from '../../../utils/fundingHasNoInformation';
+import { getStrippedFundingSourceName } from '../../Home/utils/getFundingSpaceDisplayName';
 
 type EditFundingCardProps = {
   child: Child;
@@ -121,7 +122,7 @@ export const EditFundingCard: React.FC<EditFundingCardProps> = ({
           {funding.fundingSpace ? (
             <Tag
               className="margin-top-0"
-              text={funding.fundingSpace.source.split('-')[1].trim()}
+              text={getStrippedFundingSourceName(funding.fundingSpace.source)}
             />
           ) : (
             InlineIcon({ icon: 'incomplete' })

--- a/client/src/containers/EditRecord/EnrollmentFunding/EditFundingCard.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/EditFundingCard.tsx
@@ -119,7 +119,10 @@ export const EditFundingCard: React.FC<EditFundingCardProps> = ({
         <div className="flex-1">
           <p className="margin-bottom-0">Funding</p>
           {funding.fundingSpace ? (
-            <Tag className="margin-top-0" text={funding.fundingSpace.source} />
+            <Tag
+              className="margin-top-0"
+              text={funding.fundingSpace.source.split('-')[0].trim()}
+            />
           ) : (
             InlineIcon({ icon: 'incomplete' })
           )}

--- a/client/src/containers/Home/utils/mapFundingSpacesToCards.tsx
+++ b/client/src/containers/Home/utils/mapFundingSpacesToCards.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Card } from '@ctoec/component-library';
 import { NestedFundingSpaces } from '../../../shared/payloads/NestedFundingSpaces';
 import { AgeGroup, FundingSource } from '../../../shared/models';
+import { getStrippedFundingSourceName } from './getFundingSpaceDisplayName';
 
 // Map each calculated funding space distribution into a card
 // element that we can format for display
@@ -10,7 +11,9 @@ export const mapFundingSpacesToCards = (nestedSpaces: NestedFundingSpaces) =>
     <div className="desktop:grid-col-4 three-column-card">
       <Card>
         <div className="padding-0">
-          <h3 className="margin-top-0">{source.split('-')[1]}</h3>
+          <h3 className="margin-top-0">
+            {getStrippedFundingSourceName(source as FundingSource)}
+          </h3>
           {Object.keys(nestedSpaces[source as FundingSource]).map(
             (ageGroup) => (
               <>

--- a/client/src/containers/Home/utils/mapFundingSpacesToCards.tsx
+++ b/client/src/containers/Home/utils/mapFundingSpacesToCards.tsx
@@ -10,7 +10,7 @@ export const mapFundingSpacesToCards = (nestedSpaces: NestedFundingSpaces) =>
     <div className="desktop:grid-col-4 three-column-card">
       <Card>
         <div className="padding-0">
-          <h3 className="margin-top-0">{source}</h3>
+          <h3 className="margin-top-0">{source.split('-')[1]}</h3>
           {Object.keys(nestedSpaces[source as FundingSource]).map(
             (ageGroup) => (
               <>

--- a/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
+++ b/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Divider from '@material-ui/core/Divider';
-import { Child, FundingSource, FundingSource } from '../../shared/models';
+import { Child, FundingSource } from '../../shared/models';
 import { getCurrentFunding } from '../../utils/models';
 import { getStrippedFundingSourceName } from '../Home/utils/getFundingSpaceDisplayName';
 

--- a/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
+++ b/client/src/containers/Roster/RosterSectionFundingSpacesMap.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Divider from '@material-ui/core/Divider';
-import { Child } from '../../shared/models';
+import { Child, FundingSource, FundingSource } from '../../shared/models';
 import { getCurrentFunding } from '../../utils/models';
+import { getStrippedFundingSourceName } from '../Home/utils/getFundingSpaceDisplayName';
 
 type RosterSectionFundingSpacesMapProps = {
   children: Child[];
@@ -74,7 +75,9 @@ export const RosterSectionFundingSpacesMap: React.FC<RosterSectionFundingSpacesM
           <>
             <div key={sourceToTimes.sourceName} className="grid-row grid-gap">
               <div className="tablet:grid-col-3 font-body-sm text-bold margin-top-1 margin-left-2">
-                {sourceToTimes.sourceName.split('-')[1].trim()}
+                {getStrippedFundingSourceName(
+                  sourceToTimes.sourceName as FundingSource
+                )}
               </div>
               <div className="tablet:grid-col-8 font-body-sm usa-hint margin-top-1">
                 {displayStr}

--- a/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -714,7 +714,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        CDC - Child Day Care
+                         Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -756,7 +756,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        PSR - Priority School Readiness
+                         Priority School Readiness
                       </td>
                       <td
                         class="font-body-2xs"
@@ -1213,7 +1213,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        CDC - Child Day Care
+                         Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -1961,7 +1961,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        CDC - Child Day Care
+                         Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -2000,7 +2000,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        PSR - Priority School Readiness
+                         Priority School Readiness
                       </td>
                       <td
                         class="font-body-2xs"
@@ -2414,7 +2414,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        CDC - Child Day Care
+                         Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -3090,7 +3090,7 @@ exports[`Roster matches snapshot for site level user 1`] = `
                   <td
                     class="font-body-2xs"
                   >
-                    CDC - Child Day Care
+                     Child Day Care
                   </td>
                   <td
                     class="font-body-2xs"
@@ -3129,7 +3129,7 @@ exports[`Roster matches snapshot for site level user 1`] = `
                   <td
                     class="font-body-2xs"
                   >
-                    PSR - Priority School Readiness
+                     Priority School Readiness
                   </td>
                   <td
                     class="font-body-2xs"
@@ -3543,7 +3543,7 @@ exports[`Roster matches snapshot for site level user 1`] = `
                   <td
                     class="font-body-2xs"
                   >
-                    CDC - Child Day Care
+                     Child Day Care
                   </td>
                   <td
                     class="font-body-2xs"
@@ -4280,7 +4280,7 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        CDC - Child Day Care
+                         Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -4319,7 +4319,7 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        PSR - Priority School Readiness
+                         Priority School Readiness
                       </td>
                       <td
                         class="font-body-2xs"
@@ -4733,7 +4733,7 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                        CDC - Child Day Care
+                         Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"

--- a/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
+++ b/client/src/containers/Roster/__snapshots__/Roster.test.tsx.snap
@@ -714,7 +714,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Child Day Care
+                        Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -756,7 +756,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Priority School Readiness
+                        Priority School Readiness
                       </td>
                       <td
                         class="font-body-2xs"
@@ -1213,7 +1213,7 @@ exports[`Roster matches snapshot for multi-org user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Child Day Care
+                        Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -1961,7 +1961,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Child Day Care
+                        Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -2000,7 +2000,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Priority School Readiness
+                        Priority School Readiness
                       </td>
                       <td
                         class="font-body-2xs"
@@ -2414,7 +2414,7 @@ exports[`Roster matches snapshot for one-org, multi-site user 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Child Day Care
+                        Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -3090,7 +3090,7 @@ exports[`Roster matches snapshot for site level user 1`] = `
                   <td
                     class="font-body-2xs"
                   >
-                     Child Day Care
+                    Child Day Care
                   </td>
                   <td
                     class="font-body-2xs"
@@ -3129,7 +3129,7 @@ exports[`Roster matches snapshot for site level user 1`] = `
                   <td
                     class="font-body-2xs"
                   >
-                     Priority School Readiness
+                    Priority School Readiness
                   </td>
                   <td
                     class="font-body-2xs"
@@ -3543,7 +3543,7 @@ exports[`Roster matches snapshot for site level user 1`] = `
                   <td
                     class="font-body-2xs"
                   >
-                     Child Day Care
+                    Child Day Care
                   </td>
                   <td
                     class="font-body-2xs"
@@ -4280,7 +4280,7 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Child Day Care
+                        Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"
@@ -4319,7 +4319,7 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Priority School Readiness
+                        Priority School Readiness
                       </td>
                       <td
                         class="font-body-2xs"
@@ -4733,7 +4733,7 @@ exports[`Roster matches snapshot for user at a submitted org 1`] = `
                       <td
                         class="font-body-2xs"
                       >
-                         Child Day Care
+                        Child Day Care
                       </td>
                       <td
                         class="font-body-2xs"

--- a/client/src/containers/Roster/tableColumns.tsx
+++ b/client/src/containers/Roster/tableColumns.tsx
@@ -81,11 +81,18 @@ export const tableColumns: (
       className: tableColumnClassName,
       name: ColumnNames.FUNDING_SOURCE,
       sort: (row) =>
-        idx(row, (_) => _.enrollments[0].fundings[0].fundingSpace.source) || '',
+        idx(
+          row,
+          (_) => _.enrollments[0].fundings[0].fundingSpace.source.split('-')[1]
+        ) || '',
       width: `${shortColumnWidthPercent}%`,
       cell: ({ row }) => (
         <td className={tableRowClassName}>
-          {idx(row, (_) => _.enrollments[0].fundings[0].fundingSpace.source)}
+          {idx(
+            row,
+            (_) =>
+              _.enrollments[0].fundings[0].fundingSpace.source.split('-')[1]
+          )}
         </td>
       ),
     },

--- a/client/src/containers/Roster/tableColumns.tsx
+++ b/client/src/containers/Roster/tableColumns.tsx
@@ -6,6 +6,7 @@ import { Column } from '@ctoec/component-library';
 import { Child } from '../../shared/models';
 import { IncompleteIcon } from '../../components/IncompleteIcon';
 import { nameFormatter } from '../../utils/formatters';
+import { getStrippedFundingSourceName } from '../Home/utils/getFundingSpaceDisplayName';
 
 export enum ColumnNames {
   NAME = 'Name',
@@ -81,17 +82,18 @@ export const tableColumns: (
       className: tableColumnClassName,
       name: ColumnNames.FUNDING_SOURCE,
       sort: (row) =>
-        idx(
-          row,
-          (_) => _.enrollments[0].fundings[0].fundingSpace.source.split('-')[1]
+        idx(row, (_) =>
+          getStrippedFundingSourceName(
+            _.enrollments[0].fundings[0].fundingSpace.source
+          )
         ) || '',
       width: `${shortColumnWidthPercent}%`,
       cell: ({ row }) => (
         <td className={tableRowClassName}>
-          {idx(
-            row,
-            (_) =>
-              _.enrollments[0].fundings[0].fundingSpace.source.split('-')[1]
+          {idx(row, (_) =>
+            getStrippedFundingSourceName(
+              _.enrollments[0].fundings[0].fundingSpace.source
+            )
           )}
         </td>
       ),

--- a/client/src/setupTests.ts
+++ b/client/src/setupTests.ts
@@ -3,7 +3,7 @@ import '@testing-library/jest-dom/extend-expect';
 import { enableFetchMocks } from 'jest-fetch-mock';
 import { toHaveNoViolations } from 'jest-axe';
 
-jest.setTimeout(10000);
+jest.setTimeout(60000);
 
 // adds the 'fetchMock' global variable and rewires 'fetch' global
 // to call 'fetchMock' instead of the real implementation


### PR DESCRIPTION
## Background
This PR removes the acronym from the funding source text in all the places that it's appropriate to.  Just... it's fine.

## GitHub Issue
- https://github.com/ctoec/data-collection/issues/635

## Associated PRs
N/A

## Validation Plan
Look at all parts of the application where funding sources reside (besides the data requirements page and upload template) and ensure the acronyms are gone.

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.