### PR TITLE
Remove "weeks" from all funding spaces

### DIFF
--- a/client/src/utils/formatters/fundingSpace.ts
+++ b/client/src/utils/formatters/fundingSpace.ts
@@ -1,32 +1,18 @@
-import {
-  FundingSpace,
-  FundingTime,
-  FundingTimeSplit,
-} from '../../shared/models';
+import { FundingSpace, FundingTime } from '../../shared/models';
 
 export const fundingSpaceFormatter = (fundingSpace: FundingSpace) => {
-  const FULL_YEAR_WEEKS = 52;
   if (fundingSpace.time !== FundingTime.SplitTime) {
-    return `${fundingSpace.time} (${FULL_YEAR_WEEKS} weeks)`;
+    return fundingSpace.time;
   }
 
   // Handle "split-time" funding spaces (CDC only)
-  const timeSplit = fundingSpace.timeSplit || ({} as FundingTimeSplit);
-  const fullTimeWeeks = timeSplit.fullTimeWeeks;
-  const partTimeWeeks = timeSplit.partTimeWeeks;
-  if (!fullTimeWeeks || !partTimeWeeks) {
-    // TODO: change this once we have this data
-    console.warn(
-      'Part time full time split display needs to be updated when data is available'
-    );
+  const fullTimeWeeks = fundingSpace.timeSplit?.fullTimeWeeks;
+  const partTimeWeeks = fundingSpace.timeSplit?.partTimeWeeks;
+
+  // TODO: change this once we have this data
+  if (!fullTimeWeeks || !partTimeWeeks || partTimeWeeks <= fullTimeWeeks) {
     return `${FundingTime.PartTime} / ${FundingTime.FullTime}`;
+  } else {
+    return `${FundingTime.FullTime} / ${FundingTime.PartTime}`;
   }
-
-  const fullTimeFirst = fullTimeWeeks > partTimeWeeks;
-
-  if (fullTimeFirst) {
-    return `${FundingTime.FullTime} (${fullTimeWeeks} weeks) / ${FundingTime.PartTime} (${partTimeWeeks} weeks)`;
-  }
-
-  return `${FundingTime.PartTime} (${partTimeWeeks} weeks) / ${FundingTime.FullTime} (${fullTimeWeeks} weeks)`;
 };

--- a/client/src/utils/formatters/fundingSpace.ts
+++ b/client/src/utils/formatters/fundingSpace.ts
@@ -11,6 +11,9 @@ export const fundingSpaceFormatter = (fundingSpace: FundingSpace) => {
 
   // TODO: change this once we have this data
   if (!fullTimeWeeks || !partTimeWeeks || partTimeWeeks <= fullTimeWeeks) {
+    console.warn(
+      'Part time full time split display needs to be updated when data is available'
+    );
     return `${FundingTime.PartTime} / ${FundingTime.FullTime}`;
   } else {
     return `${FundingTime.FullTime} / ${FundingTime.PartTime}`;


### PR DESCRIPTION
## Background
Update our funding space formatter to remove the `(## weeks)` text from all funding spaces across the application.

## GitHub Issue
- https://github.com/ctoec/data-collection/issues/1178

## Associated PRs
N/A

## Validation Plan
Navigate through the application and confirm that `(## weeks)` is not present in any views where funding spaces are displayed.

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.