### PR TITLE
1147: Resolves transient error that kills node process

### DIFF
--- a/src/loggers/RequestLogger.ts
+++ b/src/loggers/RequestLogger.ts
@@ -9,5 +9,5 @@ morgan.token('userId', function (req) {
 // Also, only log requests for the backend services (at /api), not the requests for the static UI content
 export const requestLogger = morgan(
   ':remote-addr - :userId [:date[clf]] ":method :url HTTP/:http-version" :status :res[content-length]',
-  { skip: (req) => !(req as Request).baseUrl.includes('api') }
+  { skip: (req) => !(req as Request).baseUrl?.includes('api') }
 );


### PR DESCRIPTION
## Background
causes type error which kills node proc. A problem in pre-prod, because this clears  + reseeds database, which should only happen on an intentional deploy or restart. 

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1147