### PR TITLE
rm ed <12yo birthday upload validation

### DIFF
--- a/src/entity/Child.ts
+++ b/src/entity/Child.ts
@@ -61,11 +61,6 @@ export class Child implements ChildInterface {
   @Column({ nullable: true, type: 'date', transformer: momentTransformer })
   @IsNotEmpty()
   @MomentComparison({
-    compareFunc: (birthdate: Moment) =>
-      birthdate.isSameOrAfter(moment().add(-12, 'years')),
-    message: 'Birthdate must be within last 12 years.',
-  })
-  @MomentComparison({
     compareFunc: (birthdate: Moment) => birthdate.isBefore(moment()),
     message: 'Birthdate cannot be in the future.',
   })


### PR DESCRIPTION
## Background
Just removed the validating decorator that checks for birthdays < 12 years old

## GitHub Issue
#1223 

## Validation Plan
- [x] Confirmed error by adding to roster with older birthday
- [x] Confirmed no error after fix with older birthday

## Automated Testing
- [ ] All unit tests are passing.
- [ ] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset.
- [ ] If applicable, e2e tests have been added to cover this changeset.