### PR TITLE
Make RP months align with user entered dates

### DIFF
--- a/src/controllers/enrollmentReports/map/mapUtils/funding.ts
+++ b/src/controllers/enrollmentReports/map/mapUtils/funding.ts
@@ -14,6 +14,7 @@ import {
 import { EnrollmentReportRow } from '../../../../template';
 import { mapEnum, mapFundingTime } from '.';
 import { EnrollmentReportUpdate } from '../uploadTypes';
+import { Moment } from 'moment';
 
 /**
  * Create a Funding object from FlattenedEnrollment source,
@@ -55,19 +56,17 @@ export const mapFunding = (
   let firstReportingPeriod: ReportingPeriod,
     lastReportingPeriod: ReportingPeriod;
   if (source.firstReportingPeriod) {
-    firstReportingPeriod = reportingPeriods.find(
-      (rp) =>
-        rp.type === fundingSource &&
-        rp.period.format('MM-YYYY') ===
-          source.firstReportingPeriod.format('MM-YYYY')
+    firstReportingPeriod = getReportingPeriodFromRow(
+      source.firstReportingPeriod,
+      reportingPeriods,
+      fundingSource
     );
   }
   if (source.lastReportingPeriod) {
-    lastReportingPeriod = reportingPeriods.find(
-      (rp) =>
-        rp.type === fundingSource &&
-        rp.period.format('MM-YYYY') ===
-          source.lastReportingPeriod.format('MM-YYYY')
+    lastReportingPeriod = getReportingPeriodFromRow(
+      source.lastReportingPeriod,
+      reportingPeriods,
+      fundingSource
     );
   }
 
@@ -214,21 +213,66 @@ export const handleFundingUpdate = (
       exitPeriod = userReportingPeriods.find(
         (rp) =>
           rp.type === currentFunding.fundingSpace.source &&
-          rp.period.format('MM-YYYY') ===
-            source.lastReportingPeriod.format('MM-YYYY')
+          reportingPeriodIncludesDate(rp, source.lastReportingPeriod)
       );
     }
 
     // Guess the most likely ending for the funding, if the user
     // didn't explicitlys upply it
     else {
-      exitPeriod = userReportingPeriods.find(
-        (rp) =>
-          rp.periodStart.isSameOrBefore(currentEnrollment.exit) &&
-          rp.periodEnd.isSameOrAfter(currentEnrollment.exit)
+      exitPeriod = userReportingPeriods.find((rp) =>
+        reportingPeriodIncludesDate(rp, currentEnrollment.exit)
       );
     }
     currentFunding.lastReportingPeriod = exitPeriod;
     fundingsToUpdate.push(currentFunding);
   }
+};
+
+/**
+ * Simple util to determine whether the periodStart and periodEnd properties
+ * of a given reporting period are date-inclusive of a given moment.
+ */
+const reportingPeriodIncludesDate = (rp: ReportingPeriod, date: Moment) => {
+  return (
+    rp.periodStart.isSameOrBefore(date) && rp.periodEnd.isSameOrAfter(date)
+  );
+};
+
+/**
+ * Handles parsing of a source row to figure out its reporting periods.
+ * The function first assumes the date is meaningful and finds an RP
+ * that includes the given date. If the period month of the result
+ * doesn't match the month of the given date, the function corrects
+ * for this by assuming the user entered MMM/YYYY format and finding
+ * the right reporting period.
+ */
+const getReportingPeriodFromRow = (
+  sourceRP: Moment,
+  reportingPeriods: ReportingPeriod[],
+  fundingSource: FundingSource
+) => {
+  // Base case: assume the day part of the date is valuable info
+  // and find a reporting period that includes the full date
+  let reportingPeriod = reportingPeriods.find(
+    (rp) =>
+      rp.type === fundingSource && reportingPeriodIncludesDate(rp, sourceRP)
+  );
+
+  // Case for correcting moment auto-parsing: if the user entered MMM/YYYY,
+  // moment auto-parsed it with '01' for the day--but, the reporting
+  // periods for some months don't include the first of the month,
+  // (i.e. "March 2020" goes from 3/2 to 3/29) so modify if needed
+  if (
+    reportingPeriod?.period.format('MM/YYYY') !== sourceRP.format('MM/YYYY') &&
+    sourceRP.date() === 1
+  ) {
+    reportingPeriod = reportingPeriods.find(
+      (rp) =>
+        rp.type === fundingSource &&
+        rp.period.format('MM/YYYY') === sourceRP.format('MM/YYYY')
+    );
+  }
+
+  return reportingPeriod;
 };

--- a/src/controllers/enrollmentReports/parse/parseUtils.ts
+++ b/src/controllers/enrollmentReports/parse/parseUtils.ts
@@ -180,10 +180,6 @@ export function getDate(value: string | number, prop: string): Moment {
   if (typeof value === 'number') {
     parsedDate = excelDateToDate(value);
   }
-  // Override the day value of funding period dates to be 01
-  if (parsedDate && prop.toLowerCase().includes('period')) {
-    return parsedDate.startOf('month');
-  }
   return parsedDate;
 }
 


### PR DESCRIPTION
## Background
Reporting periods suck because they don't align with normal month by month dates, and this makes a big headache for users. The mapping between reporting period dates and the dates they write in their sheets is completely opaque and does not need to cause them stress. This PR address a weakness in reporting period mapping by: 
1. not automatically mapping all parsed reporting period fields to have 'startOfMonth' as their day value
2. first checking if a user supplied date is "meaningful" and finding a reporting period whose start and end dates sandwich the user date (makes more sense in the code comments)
3. if a user didn't supply a day value, making sure that the found reporting period is the right one to cover their given reporting period date

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1194

## Validation Plan
Use the attached spreadsheet to:
- Confirm that the system can parse reporting periods entered in either MMM/YYYY or MM/DD/YYYY format
- Confirm that the reporting period chosen for dates entered as MM/DD/YYYY actually includes the date provided
- Confirm that the reporting period chosen for MMM/YYYY dates matches how the period should reasonably be parsed (see context below).
Spreadsheet: 
[reporting_period_test.xlsx](https://github.com/ctoec/data-collection/files/6111687/reporting_period_test.xlsx)


## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.
- [x] If applicable, unit tests have been added to cover this changeset (N/A).
- [x] If applicable, e2e tests have been added to cover this changeset (N/A).

## Additional Context
There ended up being a little bit of trickiness with knowing which RP to pull. On the one hand, we want to find RPs that actually contain the dates users give us, especially if they themselves entered the day value. But on the other hand, there are some reporting periods for which the first of a month falls in a _different_ reporting period, which generates an error that "funding can't occur before enrollment" through no fault of the user. The spreadsheet I used to test this changeset has a row with an example:

Say there's a child with an enrollment that began on March 4, 2020. Because the user was following our instructions, they entered the first funding period as 03/2020 or Mar-20. Moment will parse the period they gave as 03/01/2020, which is a date that's included in the _February_ reporting period by periodStart <= givenDate <= periodEnd. If we used this, the user would get an error and be told their funding was wrong. What the user actually intended to happen was to use the reporting period that covered dates in March. So this PR checks for whether the parsed reporting period date has the moment auto-parsed 01, and if so, it helps out the user by finding the reporting period whose _period_ (rather than start and end) matches the provided info. If that's over-commented int he code, lemme know and I'll cut it down, but I just thought this deserved some explanation (because although it overrides part of what the ticket said, I believe this is also the real intention of the ticket, to match our software's behavior with how users reasonably expect it to operate).