### PR TITLE
1212: Log children with errors when upload has errors

### DIFF
--- a/src/routes/enrollmentReports.ts
+++ b/src/routes/enrollmentReports.ts
@@ -72,7 +72,7 @@ enrollmentReportsRouter.post(
           childrenWithErrors
         );
 
-        // Log out the children with errors, without PII, to enable
+        // Log children with errors, without PII, to make troubleshooting easier
         if (enrollmentColumnErrors?.length) {
           logUploadErrors(req.user.id, childrenWithErrors);
         }
@@ -95,26 +95,27 @@ enrollmentReportsRouter.post(
   })
 );
 
+/**
+ * Helper function to log children with validation errors,
+ * without PII
+ * @param userId
+ * @param childrenWithErrors
+ */
 const logUploadErrors = (userId: number, childrenWithErrors: Child[]) => {
   console.log(
     `User ${userId} uploaded sheet with errors: ${JSON.stringify(
       childrenWithErrors
-        .filter(
-          (child) => !!child.validationErrors && child.validationErrors.length
-        )
-        .map((child) => {
-          const childToLog: object = child;
-          childToLog['lastName'] = child.lastName?.charAt(0);
-          childToLog['birthCertificateId'] = child.birthCertificateId?.replace(
-            /./g,
-            '#'
-          );
-          childToLog['birthdate'] = child.birthdate?.format('MM/YYYY');
-          childToLog['family'][
-            'streetAddress'
-          ] = child.family?.streetAddress?.replace(/./g, '#');
-          return childToLog;
-        })
+        .filter((child) => child.validationErrors?.length)
+        .map((child) => ({
+          ...child,
+          lastName: child.lastName?.charAt(0),
+          birthCertificateId: child.birthCertificateId?.replace(/./g, '#'),
+          birthdate: child.birthdate ? '##/##/####' : undefined,
+          family: {
+            ...child.family,
+            streetAddress: child.family?.streetAddress?.replace(/./g, '#'),
+          },
+        }))
     )}`
   );
 };

--- a/src/routes/enrollmentReports.ts
+++ b/src/routes/enrollmentReports.ts
@@ -109,7 +109,9 @@ const logUploadErrors = (userId: number, childrenWithErrors: Child[]) => {
         .map((child) => ({
           ...child,
           lastName: child.lastName?.charAt(0),
-          birthCertificateId: child.birthCertificateId?.replace(/./g, '#'),
+          birthCertificateId: child.birthCertificateId
+            ?.toString()
+            .replace(/./g, '#'),
           birthdate: child.birthdate ? '##/##/####' : undefined,
           family: {
             ...child.family,


### PR DESCRIPTION
## Background
When a user attempts an upload and their data has errors, it is very hard to diagnose their issues. This adds logging (with redacted PII) to hopefully make it easier for us to debug + resolve data errors without requiring users to send us their data files.

## GitHub Issue
#1212 

## Associated PRs
N/A

## Validation Plan
Confirm logging in deployed envs when upload with errors is attempted

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.