### PR TITLE
1238: accepts income not disclosed even if other values are provided

### DIFF
--- a/src/controllers/enrollmentReports/map/mapUtils/incomeDetermination.ts
+++ b/src/controllers/enrollmentReports/map/mapUtils/incomeDetermination.ts
@@ -13,30 +13,13 @@ export const mapIncomeDetermination = (
   source: EnrollmentReportRow,
   family: Family
 ) => {
-  // If the user supplied any of the income determination value fields,
-  // create the det and overwrite not disclosed to false
-  if (source.numberOfPeople || source.income || source.determinationDate) {
-    return getManager().create(IncomeDetermination, {
-      numberOfPeople: getFirstInt(source.numberOfPeople),
-      income: getFloat(source.income),
-      determinationDate: source.determinationDate,
-      incomeNotDisclosed: false,
-      family,
-    });
-  }
-
-  // If there are no provided values and user deliberately checked not
-  // disclosed, then make an undisclosed income determination
-  else if (source.incomeNotDisclosed) {
-    return getManager().create(IncomeDetermination, {
-      incomeNotDisclosed: true,
-      family,
-    });
-  } else {
-    return getManager().create(IncomeDetermination, {
-      family,
-    });
-  }
+  return getManager().create(IncomeDetermination, {
+    numberOfPeople: getFirstInt(source.numberOfPeople),
+    income: getFloat(source.income),
+    determinationDate: source.determinationDate,
+    incomeNotDisclosed: source.incomeNotDisclosed || false,
+    family,
+  });
 };
 
 /**


### PR DESCRIPTION
## Background
Right now, '"incomeNotDisclosed" value is ignored if income, householdsize, or determination date are provided.
Instead, accept all user input and allow them to define "income not disclosed" regardless of other values. 

## GitHub Issue
#1238 

## Associated PRs
N/A

## Validation Plan
- [ ] Upload a row with missing (income/householdsize/determinationdate) and income not disclosed = Yes
- [ ] confirm that the data is captured correctly, and there is no missing info alert  for the row
- [ ] confirm that in the child detail page, the determination is correctly displayed as "not disclosed" 

## Automated Testing
- [ ] All unit tests are passing.
- [ ] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset.
- [ ] If applicable, e2e tests have been added to cover this changeset