### PR TITLE
Make single endpoint instead of multiple calls

### DIFF
--- a/client/src/containers/Home/Home.test.tsx
+++ b/client/src/containers/Home/Home.test.tsx
@@ -24,9 +24,16 @@ const userProps = {
   setConfidentialityAgreedDate: () => {},
 };
 
+const authProps = {
+  loading: false,
+  accessToken: 'notBlank',
+};
+
 const HomeWithUserProvider = (
   <UserContext.Provider value={{ ...userProps }}>
-    <Home />
+    <AuthenticationContext.Provider value={{ ...authProps }}>
+      <Home />
+    </AuthenticationContext.Provider>
   </UserContext.Provider>
 );
 
@@ -40,6 +47,7 @@ jest.mock('../../utils/api');
 import * as api from '../../utils/api';
 import { waitFor } from '@testing-library/react';
 import { RevisionRequest } from './RevisionRequest';
+import AuthenticationContext from '../../contexts/AuthenticationContext/AuthenticationContext';
 const apiMock = api as jest.Mocked<typeof api>;
 
 describe('Home', () => {

--- a/client/src/containers/Home/Home.test.tsx
+++ b/client/src/containers/Home/Home.test.tsx
@@ -46,7 +46,7 @@ describe('Home', () => {
   snapshotTestHelper(HomeWithUserProvider, {
     before: async () => {
       apiMock.apiGet.mockReturnValue(
-        new Promise((resolve) => resolve({ submitted: false }))
+        new Promise((resolve) => resolve({ allSubmitted: false }))
       );
       return waitFor(() => expect(apiMock.apiGet).toBeCalled());
     },
@@ -57,7 +57,7 @@ describe('Home', () => {
   snapshotTestHelper(HomeWithUserProvider, {
     before: async () => {
       apiMock.apiGet.mockReturnValue(
-        new Promise((resolve) => resolve({ submitted: true }))
+        new Promise((resolve) => resolve({ allSubmitted: true }))
       );
       return waitFor(() => expect(apiMock.apiGet).toBeCalled());
     },
@@ -69,7 +69,7 @@ describe('Home', () => {
     wrapInRouter: true,
     before: async () => {
       apiMock.apiGet.mockReturnValue(
-        new Promise((resolve) => resolve({ submitted: true }))
+        new Promise((resolve) => resolve({ allSubmitted: true }))
       );
       return waitFor(() => expect(apiMock.apiGet).toBeCalled());
     },

--- a/client/src/containers/Home/Home.tsx
+++ b/client/src/containers/Home/Home.tsx
@@ -9,33 +9,24 @@ import { LoadingWrapper } from '@ctoec/component-library';
 const Home: React.FC = () => {
   const { user } = useContext(UserContext);
   const { accessToken } = useContext(AuthenticationContext);
-  const orgsToCheck = (user?.organizations || []).length;
 
   // Want to show the presubmit page unless every org the user represents
   // has submitted their data (corner case cuz there's only one user who
   // has multiple orgs)
-  const [isPostSubmit, setIsPostSubmit] = useState<boolean | undefined>();
-  const [numCheckedOrgs, setNumCheckedOrgs] = useState<number>(0);
+  const [isPostSubmit, setIsPostSubmit] = useState<boolean | undefined>(
+    undefined
+  );
   useEffect(() => {
-    user?.organizations?.forEach((org) => {
-      apiGet(`oec-report/${org.id}`, accessToken).then((res) => {
-        if (!res.submitted) {
-          setIsPostSubmit(false);
-        }
-        setNumCheckedOrgs((n) => n + 1);
-      });
-    });
+    (async function checkSubmitStatus() {
+      if (user && accessToken) {
+        const { allSubmitted } = await apiGet(
+          'oec-report/are-all-orgs-submitted',
+          accessToken
+        );
+        setIsPostSubmit(allSubmitted);
+      }
+    })();
   }, [user, accessToken]);
-
-  useEffect(() => {
-    // Need this second state variable because the timing of React executing
-    // checks vs the dispatch of setting postSubmit after the API call leads
-    // to flashing if isPostSubmit can be altered after it's already been
-    // set
-    if (isPostSubmit === undefined && numCheckedOrgs === orgsToCheck) {
-      setIsPostSubmit(true);
-    }
-  }, [numCheckedOrgs]);
 
   return (
     <LoadingWrapper loading={isPostSubmit === undefined}>

--- a/src/controllers/oecReport.ts
+++ b/src/controllers/oecReport.ts
@@ -1,7 +1,8 @@
 import { OECReport, User } from '../entity';
-import { getManager } from 'typeorm';
+import { getManager, In } from 'typeorm';
 import { OECReport as OECReportInterface } from '../../client/src/shared/models';
 import { BadRequestError } from '../middleware/error/errors';
+import { getReadAccessibleOrgIds } from '../utils/getReadAccessibleOrgIds';
 
 export async function createOecReport(
   user: User,
@@ -21,4 +22,14 @@ export async function createOecReport(
     },
   });
   await getManager().save(report);
+}
+
+export async function checkIfAllOrgsSubmitted(user: User) {
+  const orgIds = await getReadAccessibleOrgIds(user);
+  const foundOrgs = await getManager().find(OECReport, {
+    where: { organizationId: In(orgIds) },
+  });
+  return orgIds.every((oid) =>
+    foundOrgs.some((foundOrg) => foundOrg.id === Number(oid))
+  );
 }

--- a/src/controllers/oecReport.ts
+++ b/src/controllers/oecReport.ts
@@ -26,10 +26,11 @@ export async function createOecReport(
 
 export async function checkIfAllOrgsSubmitted(user: User) {
   const orgIds = await getReadAccessibleOrgIds(user);
-  const foundOrgs = await getManager().find(OECReport, {
+  const foundReports = await getManager().find(OECReport, {
     where: { organizationId: In(orgIds) },
   });
+  
   return orgIds.every((oid) =>
-    foundOrgs.some((foundOrg) => foundOrg.id === Number(oid))
+    foundReports.some((foundReport: OECReport) => foundReport.organizationId === Number(oid))
   );
 }

--- a/src/routes/oecReport.ts
+++ b/src/routes/oecReport.ts
@@ -17,7 +17,7 @@ oecReportRouter.get(
 oecReportRouter.get(
   `/:organizationId`,
   passAsyncError(async (req: Request, res: Response) => {
-    const organizationId = Number(req['organizationId']);
+    const organizationId: number = Number(req.params['organizationId']);
     const foundOrg = await getManager().findOne(OECReport, {
       where: { organizationId },
     });

--- a/src/routes/oecReport.ts
+++ b/src/routes/oecReport.ts
@@ -7,9 +7,17 @@ import { passAsyncError } from '../middleware/error/passAsyncError';
 export const oecReportRouter = express.Router();
 
 oecReportRouter.get(
-  '/:organizationId',
+  '/are-all-orgs-submitted',
   passAsyncError(async (req: Request, res: Response) => {
-    const organizationId: number = Number(req.params['organizationId']);
+    const allSubmitted = await controller.checkIfAllOrgsSubmitted(req.user);
+    res.send({ allSubmitted });
+  })
+);
+
+oecReportRouter.get(
+  `/:organizationId`,
+  passAsyncError(async (req: Request, res: Response) => {
+    const organizationId = Number(req['organizationId']);
     const foundOrg = await getManager().findOne(OECReport, {
       where: { organizationId },
     });


### PR DESCRIPTION
## Background
This PR addresses the inefficiency of making an API call for each org a user is associated with, changing that instead to be a single API call that uses different SQL to fetch and check all accessible organizations at once.

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1190

## Associated PRs
- https://github.com/skylight-hq/ctoec-devops/pull/206

## Validation Plan
Validation involved testing the home page as both a pre and a post-submit user. I ensured that the correct number of API calls were made in each case, and that the page was correctly shown to a user based on their submission status.

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.
- [x] If applicable, unit tests have been added to cover this changeset (I did modify the `Home.test.tsx` file to wrap the page in an `AuthenticationContext.Provider`, since the test needs to also mock an `accessToken` now to trigger the call).