### PR TITLE
Disable SQL logging by default

### DIFF
--- a/ormconfig.js
+++ b/ormconfig.js
@@ -12,7 +12,7 @@ module.exports = {
   database: process.env.DB_NAME || 'master',
   synchronize: false,
   migrationsRun: true,
-  logging: true,
+  logging: false,
   entities: ['dist/src/entity/**/*.js'],
   migrations: ['dist/src/migration/*.js'],
   subscribers: ['dist/src/subscriber/**/*.js'],

--- a/ormconfig.js
+++ b/ormconfig.js
@@ -12,7 +12,7 @@ module.exports = {
   database: process.env.DB_NAME || 'master',
   synchronize: false,
   migrationsRun: true,
-  logging: false,
+  logging: process.env.ENABLE_SQL_LOGS === 'true',
   entities: ['dist/src/entity/**/*.js'],
   migrations: ['dist/src/migration/*.js'],
   subscribers: ['dist/src/subscriber/**/*.js'],


### PR DESCRIPTION
## Background
Our current CloudWatch logs are ~99% SQL queries at this point, making it very difficult to find any other more meaningful logs.  This PR disables SQL logs across the board so we can do so moving forward.

## GitHub Issue
N/A

## Associated PRs
N/A

## Validation Plan
- [x] Deploy to test environment
- [x] Smoke test and confirm everything's functional
- [x] Confirm SQL logs stop getting written

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.