### PR TITLE
Fixed misc test types

### DIFF
--- a/client/src/components/Forms/ChildInfo/ChildInfo.test.tsx
+++ b/client/src/components/Forms/ChildInfo/ChildInfo.test.tsx
@@ -4,13 +4,14 @@ import {
   accessibilityTestHelper,
 } from '../../../testHelpers';
 import { ChildInfoForm } from './Form';
-import { Family } from '../../../shared/models';
+import { Family, Organization } from '../../../shared/models';
 
 const child = {
   id: '00000000-0000-0000-0000-000000000000',
   firstName: 'First',
   lastName: 'Last',
   family: {} as Family,
+  organization: {} as Organization,
 };
 
 describe('EditRecord', () => {

--- a/client/src/components/Forms/Enrollment/Enrollment.test.tsx
+++ b/client/src/components/Forms/Enrollment/Enrollment.test.tsx
@@ -26,12 +26,14 @@ const child = {
     {
       id: 1,
       child: {} as Child,
+      childId: '',
       site: { siteName: 'Site A', organization: { id: 1 } } as Site,
       entry: moment.utc('2020-09-03'),
     },
     {
       id: 2,
       child: {} as Child,
+      childId: '',
       site: { siteName: 'Site B', organization: { id: 1 } } as Site,
       entry: moment.utc('2019-09-03'),
       exit: moment.utc('2020-08-01'),
@@ -56,6 +58,7 @@ describe('Forms', () => {
         child={child}
         afterSaveSuccess={jest.fn()}
         setAlerts={jest.fn()}
+        topHeadingLevel="h2"
       />,
       { wrapInRouter: true }
     );
@@ -65,6 +68,7 @@ describe('Forms', () => {
         child={child}
         afterSaveSuccess={jest.fn()}
         setAlerts={jest.fn()}
+        topHeadingLevel="h2"
       />,
       { wrapInRouter: true }
     );

--- a/client/src/components/Forms/Enrollment/Funding/Funding.test.tsx
+++ b/client/src/components/Forms/Enrollment/Funding/Funding.test.tsx
@@ -26,12 +26,14 @@ const child = {
     {
       id: 1,
       child: {} as Child,
+      childId: '',
       site: { siteName: 'Site A', organization: { id: 1 } } as Site,
       entry: moment.utc('2020-09-03'),
     },
     {
       id: 2,
       child: {} as Child,
+      childId: '',
       site: { siteName: 'Site B', organization: { id: 1 } } as Site,
       entry: moment.utc('2019-09-03'),
       exit: moment.utc('2020-08-01'),
@@ -60,6 +62,7 @@ describe('Forms', () => {
         fundingId={1}
         afterSaveSuccess={jest.fn()}
         setAlerts={jest.fn()}
+        topHeadingLevel="h2"
       />,
       { wrapInRouter: true }
     );
@@ -72,6 +75,7 @@ describe('Forms', () => {
         fundingId={1}
         afterSaveSuccess={jest.fn()}
         setAlerts={jest.fn()}
+        topHeadingLevel="h2"
       />,
       { wrapInRouter: true }
     );

--- a/client/src/components/Forms/FamilyIncome/FamilyIncome.test.tsx
+++ b/client/src/components/Forms/FamilyIncome/FamilyIncome.test.tsx
@@ -37,6 +37,7 @@ describe('EditForms', () => {
         child={child}
         afterSaveSuccess={jest.fn()}
         setAlerts={jest.fn()}
+        topHeadingLevel="h2"
       />,
       { wrapInRouter: true }
     );
@@ -46,6 +47,7 @@ describe('EditForms', () => {
         child={child}
         afterSaveSuccess={jest.fn()}
         setAlerts={jest.fn()}
+        topHeadingLevel="h2"
       />,
       { wrapInRouter: true }
     );

--- a/client/src/containers/BatchEdit/EnrollmentFunding/Form.test.tsx
+++ b/client/src/containers/BatchEdit/EnrollmentFunding/Form.test.tsx
@@ -85,6 +85,7 @@ describe('BatchEdit', () => {
         afterSaveSuccess={jest.fn}
         setAlerts={jest.fn()}
         showFieldOrFieldset={showFieldInBatchEditForm}
+        topHeadingLevel="h3"
       />,
       { wrapInRouter: true }
     );
@@ -95,6 +96,7 @@ describe('BatchEdit', () => {
         afterSaveSuccess={jest.fn}
         setAlerts={jest.fn()}
         showFieldOrFieldset={showFieldInBatchEditForm}
+        topHeadingLevel="h3"
       />,
       { wrapInRouter: true }
     );
@@ -106,6 +108,7 @@ describe('BatchEdit', () => {
           afterSaveSuccess={jest.fn}
           setAlerts={jest.fn()}
           showFieldOrFieldset={showFieldInBatchEditForm}
+          topHeadingLevel="h3"
         />,
         { wrapInRouter: true }
       );

--- a/client/src/containers/EditRecord/DeleteRecord/DeleteRecord.test.tsx
+++ b/client/src/containers/EditRecord/DeleteRecord/DeleteRecord.test.tsx
@@ -21,7 +21,7 @@ const expandModal = async (renderResult: RenderResult) => {
 describe('EditRecord', () => {
   describe('DeleteRecord', () => {
     it('matches snapshot', async () => {
-      await renderHelper(<DeleteRecord child={child} />, {
+      await renderHelper(<DeleteRecord child={child} setAlerts={jest.fn()} />, {
         before: expandModal,
       });
 
@@ -30,7 +30,7 @@ describe('EditRecord', () => {
     });
 
     it('passes AXE accessibility checks', async () => {
-      await renderHelper(<DeleteRecord child={child} />, {
+      await renderHelper(<DeleteRecord child={child} setAlerts={jest.fn()} />, {
         before: expandModal,
       });
 

--- a/client/src/containers/EditRecord/EnrollmentFunding/ChangeEnrollment/ChangeEnrollment.test.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/ChangeEnrollment/ChangeEnrollment.test.tsx
@@ -19,6 +19,7 @@ import { fireEvent, wait } from '@testing-library/dom';
 
 const enrollment = {
   child: {} as Child,
+  childId: '',
   id: 1,
   site: { id: 1, siteName: 'Site' } as Site,
   ageGroup: AgeGroup.InfantToddler,
@@ -61,6 +62,8 @@ describe('EditRecord', () => {
           child={child}
           currentEnrollment={enrollment}
           afterSaveSuccess={jest.fn()}
+          noRecordedEnrollments={false}
+          setAlerts={jest.fn()}
           topHeadingLevel="h2"
         />,
         { before: waitExpandChangeEnrollment }
@@ -71,6 +74,8 @@ describe('EditRecord', () => {
           child={child}
           currentEnrollment={enrollment}
           afterSaveSuccess={jest.fn()}
+          noRecordedEnrollments={false}
+          setAlerts={jest.fn()}
           topHeadingLevel="h2"
         />,
         { before: waitExpandChangeEnrollment }

--- a/client/src/containers/EditRecord/EnrollmentFunding/ChangeFunding/ChangeFunding.test.tsx
+++ b/client/src/containers/EditRecord/EnrollmentFunding/ChangeFunding/ChangeFunding.test.tsx
@@ -18,6 +18,7 @@ import { fireEvent, wait } from '@testing-library/dom';
 
 const enrollment = {
   child: {} as Child,
+  childId: '',
   id: 1,
   site: { id: 1, siteName: 'Site' } as Site,
   ageGroup: AgeGroup.InfantToddler,
@@ -71,6 +72,7 @@ describe('EditRecord', () => {
             enrollment={enrollment}
             orgId={1}
             afterSaveSuccess={jest.fn()}
+            setAlerts={jest.fn()}
             topHeadingLevel="h3"
           />,
           { before, name }
@@ -80,6 +82,7 @@ describe('EditRecord', () => {
             enrollment={enrollment}
             orgId={1}
             afterSaveSuccess={jest.fn()}
+            setAlerts={jest.fn()}
             topHeadingLevel="h2"
           />,
           { before, name }


### PR DESCRIPTION
## Background
Hopefully straightforward quixfix for tests' types.

I fixed an issue with my VSCode where I now check types project-wide on save. Errors related to these changes came up. At first I dismissed them figuring my project-wide config was broken. It kind of is in that it checks these types while our `tsc` doesn't. But the types _are_ wrong. So updating them here.