### PR TITLE
1246: Update child count in admin view to include only children with active enrollment

### DIFF
--- a/src/controllers/summary.ts
+++ b/src/controllers/summary.ts
@@ -4,7 +4,6 @@ import {
 } from '../../client/src/shared/payloads/SummaryResponse';
 import { getManager } from 'typeorm';
 import { Child, Organization, User } from '../entity';
-import moment from 'moment';
 
 export async function getSummaryResponse(): Promise<SummaryResponse> {
   const sites = await getSiteSummaries();
@@ -43,12 +42,9 @@ async function getChildCount(): Promise<number> {
     getManager()
       .createQueryBuilder(Child, 'Child')
       .leftJoinAndSelect('Child.enrollments', 'enrollment')
+      .where('enrollment.deletedDate IS NULL')
       // Only count children who are associated with a current enrollment
-      .where(
-        `enrollment.deletedDate IS NULL AND enrollment.exit <= CONVERT(date, '${moment
-          .utc()
-          .toISOString()}')`
-      )
+      .andWhere('enrollment.exit IS NULL')
       .getCount()
   );
 }


### PR DESCRIPTION
## Background
First pass at this naively grabbed all children in the system. Later testing/review revealed that this should actually just be the total number of children *with a current, active enrollment*

## GitHub Issue
#1246 

## Associated PRs
N/A

## Validation Plan
- [x] confirm SQL generated by queryBuilder is correct
- [x] confirm number reflects only children with active enrollments (not those that are fully withdrawn)

## Automated Testing
- [x] All unit tests are passing.
- [ ] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset.
- [ ] If applicable, e2e tests have been added to cover this changeset.

## Additional Context
Jay wants to invite OEC users to the tool on thursday, so there's a bit of a due date on this 