### PR TITLE
Fixed postsub count

### DIFF
--- a/client/src/integrationTests/children.test.ts
+++ b/client/src/integrationTests/children.test.ts
@@ -47,9 +47,8 @@ describe('integration', () => {
 
       it('GET /children/count', async () => {
         const active = await apiGet('children', '', TEST_OPTS);
-        const withdrawn = await apiGet('children/withdrawn', '', TEST_OPTS);
         const { count } = await apiGet('children/metadata', '', TEST_OPTS);
-        expect(count).toEqual(active.length + withdrawn.length);
+        expect(count).toEqual(active.length);
       });
 
       it('GET /children?organizationId', async () => {

--- a/src/routes/children.ts
+++ b/src/routes/children.ts
@@ -23,7 +23,7 @@ childrenRouter.get(
     const organizationIds = parseQueryString(req, 'organizationId', {
       forceArray: true,
     }) as string[];
-    const activeMonth = parseQueryString(req, 'month', {
+    const month = parseQueryString(req, 'month', {
       post: (monthStr) => moment.utc(monthStr, 'MMM-YYYY'),
     }) as Moment;
     const skip = parseQueryString(req, 'skip', { post: parseInt }) as number;
@@ -32,7 +32,7 @@ childrenRouter.get(
       req.user,
       organizationIds,
       {
-        activeMonth,
+        month,
         skip,
         take,
       }


### PR DESCRIPTION
Now on active children, previously on all children

## Background
Used the existing `getActiveChildren` fn and abstracted the query so we can now get the `count` and `children`, which should then be identical 

## GitHub Issue
#1195 

## Associated PRs
N / A

## Validation Plan
Seems like the issue is around withdrawn children, so:
- [x] Withdrawn a child from the roster and check the count is updated appropriately 

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.