### PR TITLE
Bump SSRI version used by Webpack

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -42,6 +42,9 @@
     "typescript": "^3.9.5",
     "uswds": "2.9.0"
   },
+  "resolutions": {
+    "react-scripts/webpack/**/ssri": "6.0.2"
+  },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -11723,10 +11723,10 @@ sshpk@^1.7.0:
     safer-buffer "^2.0.2"
     tweetnacl "~0.14.0"
 
-ssri@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.1.tgz#2a3c41b28dd45b62b63676ecb74001265ae9edd8"
-  integrity sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==
+ssri@6.0.2, ssri@^6.0.1:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/ssri/-/ssri-6.0.2.tgz#157939134f20464e7301ddba3e90ffa8f7728ac5"
+  integrity sha512-cepbSq/neFK7xB6A50KHN0xHDotYzq58wWCa5LeWqnPrHG8GzfEjO/4O8kpmcGW+oaxkvhEJCWgbgNk4/ZV93Q==
   dependencies:
     figgy-pudding "^3.5.1"
 


### PR DESCRIPTION
## Background
[Vulnerability found](https://github.com/webpack-contrib/terser-webpack-plugin/issues/388) with the version of `ssri` used by `webpack`, referenced by `react-scripts`.  This bumps that specific hotfix version of `ssri` used exclusively by `webpack` to [the version where this is fixed](https://github.com/npm/ssri/issues/18), until they get around to it.

## GitHub Issue
N/A

## Associated PRs
If applicable, replace this text with links to additional pull requests associated with this work.

## Validation Plan
- [x] Successfully build and deploy the app

## Automated Testing
- [x] All unit tests are passing.
- [ ] All e2e tests are passing.