### PR TITLE
Bump z-index of all modals

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ctoec/component-library": "^1.1.14",
+    "@ctoec/component-library": "https://github.com/ctoec/component-library.git#modal-fix",
     "@openid/appauth": "^1.2.7",
     "@testing-library/dom": "^7.24.1",
     "@testing-library/jest-dom": "^4.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ctoec/component-library": "https://github.com/ctoec/component-library.git#modal-fix",
+    "@ctoec/component-library": "https://github.com/ctoec/component-library.git#proper-modal-fix",
     "@openid/appauth": "^1.2.7",
     "@testing-library/dom": "^7.24.1",
     "@testing-library/jest-dom": "^4.2.4",

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@ctoec/component-library": "https://github.com/ctoec/component-library.git#proper-modal-fix",
+    "@ctoec/component-library": "https://github.com/ctoec/component-library#v1.1.14.1",
     "@openid/appauth": "^1.2.7",
     "@testing-library/dom": "^7.24.1",
     "@testing-library/jest-dom": "^4.2.4",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1250,10 +1250,9 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@ctoec/component-library@^1.1.14":
-  version "1.1.14"
-  resolved "https://registry.yarnpkg.com/@ctoec/component-library/-/component-library-1.1.14.tgz#a9973c933ae6eb2466168d15c5daf1b2515e81dc"
-  integrity sha512-AGyE7cyMQiBSBnsyUfNfjERSwUehXAt+WBntzYByTVFVWYm0xIJm73pGwXChpal/GwyvaJYfnZhN0NFtNGW6Ew==
+"@ctoec/component-library@https://github.com/ctoec/component-library.git#modal-fix":
+  version "1.1.15"
+  resolved "https://github.com/ctoec/component-library.git#274f7362bd2b0788cb4c29d16e03ca19828163b6"
   dependencies:
     "@types/carbon-components" "^10.23.0"
     "@types/carbon-components-react" "^7.26.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1250,6 +1250,29 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
+"@ctoec/component-library@https://github.com/ctoec/component-library#v1.1.14.1":
+  version "1.1.14"
+  resolved "https://github.com/ctoec/component-library#750ea0e86dbf6a916a6b27ea5fdeb9d4a3531bd0"
+  dependencies:
+    "@types/carbon-components" "^10.23.0"
+    "@types/carbon-components-react" "^7.26.0"
+    "@types/pluralize" "^0.0.29"
+    "@types/react-modal" "^3.10.6"
+    carbon-components "^10.25.0"
+    carbon-components-react "^7.25.0"
+    carbon-icons "^7.0.7"
+    dompurify "^2.0.12"
+    html-react-parser "^0.13.0"
+    lodash "^4.17.15"
+    pluralize "^8.0.0"
+    react "^16.13.1"
+    react-dates "^21.8.0"
+    react-dom "^16.13.1"
+    react-modal "^3.11.2"
+    react-router-dom "^5.2.0"
+    typescript "^3.9.0"
+    uswds "2.9.0"
+
 "@ctoec/component-library@https://github.com/ctoec/component-library.git#proper-modal-fix":
   version "1.1.14"
   resolved "https://github.com/ctoec/component-library.git#e2b154a6d896345b096709a35cf432ac14afc115"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1250,9 +1250,9 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-10.1.0.tgz#f0950bba18819512d42f7197e56c518aa491cf18"
   integrity sha512-ij4wRiunFfaJxjB0BdrYHIH8FxBJpOwNPhhAcunlmPdXudL1WQV1qoP9un6JsEBAgQH+7UXyyjh0g7jTxXK6tg==
 
-"@ctoec/component-library@https://github.com/ctoec/component-library.git#modal-fix":
-  version "1.1.15"
-  resolved "https://github.com/ctoec/component-library.git#274f7362bd2b0788cb4c29d16e03ca19828163b6"
+"@ctoec/component-library@https://github.com/ctoec/component-library.git#proper-modal-fix":
+  version "1.1.14"
+  resolved "https://github.com/ctoec/component-library.git#e2b154a6d896345b096709a35cf432ac14afc115"
   dependencies:
     "@types/carbon-components" "^10.23.0"
     "@types/carbon-components-react" "^7.26.0"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -1273,29 +1273,6 @@
     typescript "^3.9.0"
     uswds "2.9.0"
 
-"@ctoec/component-library@https://github.com/ctoec/component-library.git#proper-modal-fix":
-  version "1.1.14"
-  resolved "https://github.com/ctoec/component-library.git#e2b154a6d896345b096709a35cf432ac14afc115"
-  dependencies:
-    "@types/carbon-components" "^10.23.0"
-    "@types/carbon-components-react" "^7.26.0"
-    "@types/pluralize" "^0.0.29"
-    "@types/react-modal" "^3.10.6"
-    carbon-components "^10.25.0"
-    carbon-components-react "^7.25.0"
-    carbon-icons "^7.0.7"
-    dompurify "^2.0.12"
-    html-react-parser "^0.13.0"
-    lodash "^4.17.15"
-    pluralize "^8.0.0"
-    react "^16.13.1"
-    react-dates "^21.8.0"
-    react-dom "^16.13.1"
-    react-modal "^3.11.2"
-    react-router-dom "^5.2.0"
-    typescript "^3.9.0"
-    uswds "2.9.0"
-
 "@dabh/diagnostics@^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@dabh/diagnostics/-/diagnostics-2.0.2.tgz#290d08f7b381b8f94607dc8f471a12c675f9db31"


### PR DESCRIPTION
## Background
Modals sometimes don't sit highest on the browser window - this PR should fix that.

## GitHub Issue
https://github.com/ctoec/component-library/issues/133

## Associated PRs
https://github.com/ctoec/component-library/pull/148

## Validation Plan
- [x] Confirm that the **withdraw child** modal sits in front of all other content on the page
- [x] Confirm that the **delete child** modal sits in front of all other content on the page
- [x] Confirm that the **roster submit success** modal sits in front of all other content on the page
- [x] Confirm that the **previous month filter** modal sits in front of all other content on the page
- [x] Confirm that the **change enrollment** modal sits in front of all other content on the page

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.