### PR TITLE
Fix Privacy Policy Links

### DIFF
--- a/client/src/containers/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/client/src/containers/PrivacyPolicy/PrivacyPolicy.tsx
@@ -137,7 +137,7 @@ const PrivacyPolicy: React.FC = () => {
       </ul>
       <p>
         Further regulations and laws as applicable may apply including state law
-        and the United States Privacy Act of 1974 
+        and the United States Privacy Act of 1974 {' '}
         <Link to={{ pathname: "http://www.archives.gov" }} target="_blank">(http://www.archives.gov)</Link>. You
         may obtain more information regarding other data security laws pertinent
         to data shared with State of Connecticut Departments and Agencies
@@ -157,7 +157,7 @@ const PrivacyPolicy: React.FC = () => {
         State of Connecticut Privacy Policy also applies. If there is not a
         specific provision in this ECE Reporter Privacy Policy, the State of
         Connecticut Privacy Policy will prevail. You may view the State of
-        Connecticut Privacy Policy here: 
+        Connecticut Privacy Policy here: {' '}
         <Link to={{ pathname: "https://portal.ct.gov/policies/state-privacy-policy/" }} target="_blank">
           https://portal.ct.gov/policies/state-privacy-policy/.
         </Link>
@@ -207,7 +207,7 @@ const PrivacyPolicy: React.FC = () => {
         carry out official duties. All such persons as defined above that has
         approved, limited access to data in ECE Reporter must comply with both
         this Privacy Policy and the State of Connecticut Privacy Policy found
-        here: 
+        here: {' '}
         <Link to={{ pathname: "https://portal.ct.gov/policies/state-privacy-policy/" }} target="_blank">
           https://portal.ct.gov/policies/state-privacy-policy/.
         </Link>

--- a/client/src/containers/PrivacyPolicy/PrivacyPolicy.tsx
+++ b/client/src/containers/PrivacyPolicy/PrivacyPolicy.tsx
@@ -137,13 +137,13 @@ const PrivacyPolicy: React.FC = () => {
       </ul>
       <p>
         Further regulations and laws as applicable may apply including state law
-        and the United States Privacy Act of 1974
-        <Link to="http://www.archives.gov">(http://www.archives.gov)</Link>. You
+        and the United States Privacy Act of 1974 
+        <Link to={{ pathname: "http://www.archives.gov" }} target="_blank">(http://www.archives.gov)</Link>. You
         may obtain more information regarding other data security laws pertinent
         to data shared with State of Connecticut Departments and Agencies
         including the OEC as explained in the State of Connecticut Privacy
-        Policy, available at the following link:{' '}
-        <Link to="https://portal.ct.gov/policies/state-privacy-policy/">
+        Policy, available at the following link: {' '}
+        <Link to={{ pathname: "https://portal.ct.gov/policies/state-privacy-policy/" }} target="_blank">
           https://portal.ct.gov/policies/state-privacy-policy/
         </Link>
         .
@@ -157,8 +157,8 @@ const PrivacyPolicy: React.FC = () => {
         State of Connecticut Privacy Policy also applies. If there is not a
         specific provision in this ECE Reporter Privacy Policy, the State of
         Connecticut Privacy Policy will prevail. You may view the State of
-        Connecticut Privacy Policy here:
-        <Link to="https://portal.ct.gov/policies/state-privacy-policy/">
+        Connecticut Privacy Policy here: 
+        <Link to={{ pathname: "https://portal.ct.gov/policies/state-privacy-policy/" }} target="_blank">
           https://portal.ct.gov/policies/state-privacy-policy/.
         </Link>
       </p>
@@ -207,8 +207,8 @@ const PrivacyPolicy: React.FC = () => {
         carry out official duties. All such persons as defined above that has
         approved, limited access to data in ECE Reporter must comply with both
         this Privacy Policy and the State of Connecticut Privacy Policy found
-        here:
-        <Link to="https://portal.ct.gov/policies/state-privacy-policy/">
+        here: 
+        <Link to={{ pathname: "https://portal.ct.gov/policies/state-privacy-policy/" }} target="_blank">
           https://portal.ct.gov/policies/state-privacy-policy/.
         </Link>
       </p>

--- a/client/src/containers/PrivacyPolicy/__snapshots__/PrivacyPolicy.test.tsx.snap
+++ b/client/src/containers/PrivacyPolicy/__snapshots__/PrivacyPolicy.test.tsx.snap
@@ -161,7 +161,7 @@ exports[`PrivacyPolicy matches snapshot 1`] = `
       </li>
     </ul>
     <p>
-      Further regulations and laws as applicable may apply including state law and the United States Privacy Act of 1974
+      Further regulations and laws as applicable may apply including state law and the United States Privacy Act of 1974  
       <a
         href="http://www.archives.gov"
         target="_blank"
@@ -181,7 +181,7 @@ exports[`PrivacyPolicy matches snapshot 1`] = `
       Does the State of Connecticut Privacy Policy apply to PII shared on ECE Reporter?
     </h2>
     <p>
-      Yes. In addition to this Privacy Policy regarding ECE Reporter, the State of Connecticut Privacy Policy also applies. If there is not a specific provision in this ECE Reporter Privacy Policy, the State of Connecticut Privacy Policy will prevail. You may view the State of Connecticut Privacy Policy here:
+      Yes. In addition to this Privacy Policy regarding ECE Reporter, the State of Connecticut Privacy Policy also applies. If there is not a specific provision in this ECE Reporter Privacy Policy, the State of Connecticut Privacy Policy will prevail. You may view the State of Connecticut Privacy Policy here:  
       <a
         href="https://portal.ct.gov/policies/state-privacy-policy/"
         target="_blank"
@@ -211,7 +211,7 @@ exports[`PrivacyPolicy matches snapshot 1`] = `
       Is my information shared with any other entity?
     </h2>
     <p>
-      We do not disclose, sell, lease or provide any personal information about our users to any other government or commercial entity for any purpose. We may link data about early care and education to public school data through the State Department of Education in order to research the benefits of ECE Reporter on educational outcomes and to study the effectiveness of the programs OEC regulates. In addition to OEC, other State of Connecticut employees approved by OEC may assist with this research. Technology contractors approved by OEC and the OEC helpdesk may also encounter PII when correcting technological issues. OEC takes precautions to limit such access to only data necessary to carry out official duties. All such persons as defined above that has approved, limited access to data in ECE Reporter must comply with both this Privacy Policy and the State of Connecticut Privacy Policy found here:
+      We do not disclose, sell, lease or provide any personal information about our users to any other government or commercial entity for any purpose. We may link data about early care and education to public school data through the State Department of Education in order to research the benefits of ECE Reporter on educational outcomes and to study the effectiveness of the programs OEC regulates. In addition to OEC, other State of Connecticut employees approved by OEC may assist with this research. Technology contractors approved by OEC and the OEC helpdesk may also encounter PII when correcting technological issues. OEC takes precautions to limit such access to only data necessary to carry out official duties. All such persons as defined above that has approved, limited access to data in ECE Reporter must comply with both this Privacy Policy and the State of Connecticut Privacy Policy found here:  
       <a
         href="https://portal.ct.gov/policies/state-privacy-policy/"
         target="_blank"

--- a/client/src/containers/PrivacyPolicy/__snapshots__/PrivacyPolicy.test.tsx.snap
+++ b/client/src/containers/PrivacyPolicy/__snapshots__/PrivacyPolicy.test.tsx.snap
@@ -163,13 +163,15 @@ exports[`PrivacyPolicy matches snapshot 1`] = `
     <p>
       Further regulations and laws as applicable may apply including state law and the United States Privacy Act of 1974
       <a
-        href="/http://www.archives.gov"
+        href="http://www.archives.gov"
+        target="_blank"
       >
         (http://www.archives.gov)
       </a>
-      . You may obtain more information regarding other data security laws pertinent to data shared with State of Connecticut Departments and Agencies including the OEC as explained in the State of Connecticut Privacy Policy, available at the following link: 
+      . You may obtain more information regarding other data security laws pertinent to data shared with State of Connecticut Departments and Agencies including the OEC as explained in the State of Connecticut Privacy Policy, available at the following link:  
       <a
-        href="/https://portal.ct.gov/policies/state-privacy-policy/"
+        href="https://portal.ct.gov/policies/state-privacy-policy/"
+        target="_blank"
       >
         https://portal.ct.gov/policies/state-privacy-policy/
       </a>
@@ -181,7 +183,8 @@ exports[`PrivacyPolicy matches snapshot 1`] = `
     <p>
       Yes. In addition to this Privacy Policy regarding ECE Reporter, the State of Connecticut Privacy Policy also applies. If there is not a specific provision in this ECE Reporter Privacy Policy, the State of Connecticut Privacy Policy will prevail. You may view the State of Connecticut Privacy Policy here:
       <a
-        href="/https://portal.ct.gov/policies/state-privacy-policy/"
+        href="https://portal.ct.gov/policies/state-privacy-policy/"
+        target="_blank"
       >
         https://portal.ct.gov/policies/state-privacy-policy/.
       </a>
@@ -210,7 +213,8 @@ exports[`PrivacyPolicy matches snapshot 1`] = `
     <p>
       We do not disclose, sell, lease or provide any personal information about our users to any other government or commercial entity for any purpose. We may link data about early care and education to public school data through the State Department of Education in order to research the benefits of ECE Reporter on educational outcomes and to study the effectiveness of the programs OEC regulates. In addition to OEC, other State of Connecticut employees approved by OEC may assist with this research. Technology contractors approved by OEC and the OEC helpdesk may also encounter PII when correcting technological issues. OEC takes precautions to limit such access to only data necessary to carry out official duties. All such persons as defined above that has approved, limited access to data in ECE Reporter must comply with both this Privacy Policy and the State of Connecticut Privacy Policy found here:
       <a
-        href="/https://portal.ct.gov/policies/state-privacy-policy/"
+        href="https://portal.ct.gov/policies/state-privacy-policy/"
+        target="_blank"
       >
         https://portal.ct.gov/policies/state-privacy-policy/.
       </a>


### PR DESCRIPTION
## Background
Turns out none of the links in our Privacy Policy actually _work_, at the moment.  This fixes that!

## GitHub Issue
N/A

## Validation Plan
- [x] Confirm all links on the Privacy Policy page open a new browser window for the user at the appropriate URL

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.