### PR TITLE
Reduce unit test memory usage

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --testPathIgnorePatterns ./*/integrationTests --logHeapUsage",
+    "test": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --testPathIgnorePatterns ./*/integrationTests --runInBand --logHeapUsage",
     "test-integration": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --runInBand --testTimeout=50000 --testPathPattern ./*/integrationTests",
     "test-local": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject"

--- a/client/package.json
+++ b/client/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --testPathIgnorePatterns ./*/integrationTests",
+    "test": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --testPathIgnorePatterns ./*/integrationTests --logHeapUsage",
     "test-integration": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --runInBand --testTimeout=50000 --testPathPattern ./*/integrationTests",
     "test-local": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject"

--- a/client/package.json
+++ b/client/package.json
@@ -48,7 +48,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --testPathIgnorePatterns ./*/integrationTests --runInBand --logHeapUsage",
+    "test": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --testPathIgnorePatterns ./*/integrationTests --runInBand",
     "test-integration": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen --silent --runInBand --testTimeout=50000 --testPathPattern ./*/integrationTests",
     "test-local": "TZ=America/New_York CI=true react-scripts test --env=jest-environment-jsdom-sixteen",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "node dist/src/index.js",
     "serve-debug": "nodemon --inspect dist/src/index.js",
     "start": "npm run serve",
-    "test": "jest",
+    "test": "jest --logHeapUsage",
     "e2e": "yarn --cwd e2e-tests test",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js ",
     "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\"",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "node dist/src/index.js",
     "serve-debug": "nodemon --inspect dist/src/index.js",
     "start": "npm run serve",
-    "test": "jest --logHeapUsage",
+    "test": "jest --runInBand --logHeapUsage",
     "e2e": "yarn --cwd e2e-tests test",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js ",
     "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\"",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "serve": "node dist/src/index.js",
     "serve-debug": "nodemon --inspect dist/src/index.js",
     "start": "npm run serve",
-    "test": "jest --runInBand --logHeapUsage",
+    "test": "jest --runInBand",
     "e2e": "yarn --cwd e2e-tests test",
     "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js ",
     "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\"",


### PR DESCRIPTION
## Background
The Docker executors our build/deploy/tests workflows run in on CircleCI have a pretty limited memory ceiling (given we're using the free version of CircleCI).  With that in mind, this PR adds the `--runInBand` parameter to our Jest unit test commands, which, [per Jest documentation](https://jestjs.io/docs/cli#--runinband), runs `"all tests serially in the current process, rather than creating a worker pool of child processes that run tests"`.  This also appears to have the added bonus of somehow [speeding up our total unit test execution time slightly](https://jestjs.io/docs/troubleshooting#tests-are-extremely-slow-on-docker-andor-continuous-integration-ci-server)!

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1227

## Validation Plan
- [x] Unit tests CircleCI workflow was run several times in succession without failure

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.