### PR TITLE
Slightly reduce excessive number of roster calls made

### DIFF
--- a/client/src/contexts/RosterContext/RosterContext.tsx
+++ b/client/src/contexts/RosterContext/RosterContext.tsx
@@ -71,6 +71,11 @@ const RosterContext = React.createContext<RosterContextType>(defaultCtx);
 
 const RosterProvider: React.FC = ({ children }) => {
   const { user } = useContext(UserContext);
+
+  if (user?.isAdmin) {
+    return <></>;
+  }
+
   const history = useHistory();
   const query: RosterQueryParams = parse(history.location.search);
 

--- a/client/src/hooks/useAuthenticatedSWR.ts
+++ b/client/src/hooks/useAuthenticatedSWR.ts
@@ -42,5 +42,8 @@ export function useAuthenticatedSWRInfinite<T>(
     const key = !path || !accessToken ? null : [path, accessToken];
     return key;
   };
-  return useSWRInfinite(getKey) as SWRInfiniteResponseInterface<T, string>;
+  return useSWRInfinite(getKey, {
+    revalidateOnFocus: false,
+    revalidateOnReconnect: false,
+  }) as SWRInfiniteResponseInterface<T, string>;
 }


### PR DESCRIPTION
## Background
While we have tickets created long-term to both [replace SWR with a library that supports a pull-through cache mechanism](https://app.zenhub.com/workspaces/ece-dev-board-5ff506028d35f30012e0e937/issues/ctoec/data-collection/1009) as well as [refactor our most expensive DB validators](https://app.zenhub.com/workspaces/ece-dev-board-5ff506028d35f30012e0e937/issues/ctoec/data-collection/1289), this PR provides some immediate relief to our DB in terms of number of GET children API requests made.  More specifically, this PR should prevent subsequent GET children API requests under the following circumstances:
- If an OEC admin user has logged in (as they don't have a roster)
- If a user clicks to another application on their computer, then clicks back
- If a user loses their internet connection briefly, and then regains it (they probably ought just refresh anyway)

## GitHub Issue
N/A

## Validation Plan
- [ ] Confirm that no GET children requests are made when logged in as an OEC admin
- [ ] Confirm that general updates made to children in-app update the cache as they did previously

## Automated Testing
- [ ] All unit tests are passing.
- [ ] All e2e tests are passing.