### PR TITLE
Create new automation environment for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,15 +174,15 @@ workflows:
             - hold
             - pull
       - build:
-          env: qa
+          env: automation
           requires:
             - install
       - deploy:
-          env: qa
+          env: automation
           requires:
             - build
       - e2e_test:
-          env: qa
+          env: automation
           requires:
             - deploy
 

--- a/.ebextensions/https-instance.config
+++ b/.ebextensions/https-instance.config
@@ -4,7 +4,7 @@ Resources:
       AWS::CloudFormation::Authentication:
         S3Auth:
           type: "s3"
-          buckets: ["ece-fawkes-prod-store", "ece-fawkes-qa-store", "ece-fawkes-staging-store", "ece-fawkes-devsecure-store"]
+          buckets: ["ece-fawkes-prod-store", "ece-fawkes-qa-store", "ece-fawkes-staging-store", "ece-fawkes-devsecure-store", "ece-fawkes-automation-store"]
           roleName: 
             "Fn::GetOptionSetting": 
               Namespace: "aws:autoscaling:launchconfiguration"

--- a/client/public/config.json
+++ b/client/public/config.json
@@ -3,6 +3,9 @@
     "WingedKeysUri": "https://qa.ece-wingedkeys.ctoecskylight.com",
     "GoogleAnalyticsTrackingId": "UA-191041839-2"
   },
+  "automation": {
+    "WingedKeysUri": "https://automation.ece-wingedkeys.ctoecskylight.com"
+  },
   "devsecure": {
     "WingedKeysUri": "https://devsecure.ece-wingedkeys.ctoecskylight.com"
   },

--- a/e2e-tests/nightwatch.conf.js
+++ b/e2e-tests/nightwatch.conf.js
@@ -16,7 +16,7 @@ https: nightwatch_config = {
     disable_error_log: true,
   },
   launch_url:
-    process.env.LAUNCH_URL || 'https://staging.ece-fawkes.ctoecskylight.com',
+    process.env.LAUNCH_URL || 'https://automation.ece-fawkes.ctoecskylight.com',
   test_settings: {
     default: {
       globals: {


### PR DESCRIPTION
## Background
This PR adds support for running our ECE Reporter e2e tests in our new dedicated `automation` environment.

## GitHub Issue
N/A

## Associated PRs
- https://github.com/skylight-hq/ctoec-devops/pull/214
- https://github.com/ctoec/winged-keys/pull/73

## Validation Plan
- [x] Fawkes can be deployed to the `automation` environment without issue
- [x] All tests pass against the new `automation` environment

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.