### PR TITLE
Fix funding space seeder bug

### DIFF
--- a/scripts/rebuild.sh
+++ b/scripts/rebuild.sh
@@ -2,8 +2,10 @@
 # applications, specifically for local development
 
 echo "Clearing out all old dependencies..."
+cd ../
 rm -rf node_modules
 rm -rf dist
+
 cd client
 rm -rf node_modules
 rm -rf build

--- a/src/data/fake/initialize.ts
+++ b/src/data/fake/initialize.ts
@@ -110,7 +110,13 @@ export const initialize = async () => {
         })
       );
 
-      if (!(await getManager().find(FundingSpace)).length) {
+      const fundingSpacesForOrg = await getManager().find(FundingSpace, {
+        where: {
+          organizationId: organization.id,
+        }
+      });
+
+      if (!fundingSpacesForOrg?.length) {
         const fundingSpacesToAdd = await Promise.all(
           getFakeFundingSpaces(organization).map((fs) => {
             return getManager().create(FundingSpace, omit(fs, 'id'));


### PR DESCRIPTION
## Background
This PR fixes a race condition with our test environment seeder.  Previously, we decided whether or not to create funding spaces for a particular organization based on if there were _any_ rows in the funding space table **at all**.  This was problematic, because occasionally the creation of funding spaces for one organization would take place prior to the creation of funding spaces for another.  And in those scenarios, because we already had data in that table, we would simply not create any funding spaces for all remaining organizations.

We no longer do that, instead checking to see if there are any funding spaces for the organization we're currently dealing with to determine whether or not they need to be created.

ALSO, I shimmied in a tiny fix to the `rebuild.sh` script, from when it was since moved to the `scripts` directory.

## GitHub Issue
N/A

## Validation Plan
- Deploy to test environments a couple times, and confirm funding spaces are created for all mock organizations

## Automated Testing
- [x] All unit tests are passing.
- [x] All e2e tests are passing.