### PR TITLE
Export unique IDs

### DIFF
--- a/src/controllers/export.ts
+++ b/src/controllers/export.ts
@@ -102,25 +102,23 @@ function flattenChild(
       return;
     } else {
       const valueFound = objectsToCheck.some((o) => {
-        if (o && o.hasOwnProperty(propertyName) || propertyName === 'sasidUniqueId') {
+        if (o && o.hasOwnProperty(propertyName)) {
+          childString.push(formatProperty(o[propertyName], propertyName));
+          return true;
+        }
+        else if (propertyName === 'sasidUniqueId') {
           // Special case: template has a joint 'sasid/unique ID' field, but
           // child objects have only 'sasid' and 'uniqueId' fields, so can't
           // check strict 'ownProperty'
-          if (propertyName === 'sasidUniqueId') {
-            if (child.organization?.uniqueIdType === UniqueIdType.SASID) {
-              childString.push(formatProperty(
-                child[UniqueIdType.SASID.toLowerCase()], UniqueIdType.SASID.toLowerCase())
-              );
-            }
-            else {
-              childString.push(formatProperty(child['uniqueId'], 'uniqueId'));
-            }
-            return true;
+          if (child.organization?.uniqueIdType === UniqueIdType.SASID) {
+            childString.push(formatProperty(
+              child[UniqueIdType.SASID.toLowerCase()], UniqueIdType.SASID.toLowerCase())
+            );
           }
           else {
-            childString.push(formatProperty(o[propertyName], propertyName));
-            return true;
+            childString.push(formatProperty(child['uniqueId'], 'uniqueId'));
           }
+          return true;
         }
         return false;
       });


### PR DESCRIPTION
## Background
The export function currently does not export SASIDs or Unique IDs saved on children to the resulting spreadsheet. This PR fixes that.

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1367

## Validation Plan
- Log into ECE Reporter
- Upload a child record
- Add or edit the SASID information for that child in the roster, and save the changes
- Export the roster
- Check the resulting spreadsheet for the successfully output SASID/UniqueId

## Automated Testing
- [x] All unit tests are passing.
- [ ] All e2e tests are passing.

## Additional Context
The issue was happening because export works using a `hasOwnProperty` call. Our template has a `sasidUniqueId` field that jointly bundles these two, but `child` objects have only `sasid` and `uniqueId` fields, so the `hasOwnProperty` check was returning false. We just needed a special case to handle a template property that doesn't map to any entity.