### PR TITLE
Fix post-refresh "Add Record" bug 

### DIFF
--- a/client/src/containers/CreateRecord/CreateRecord.tsx
+++ b/client/src/containers/CreateRecord/CreateRecord.tsx
@@ -50,7 +50,7 @@ const CreateRecord: React.FC = () => {
   // On initial load, set url hash to first step hash
   useEffect(() => {
     if (!activeStep) {
-      history.replace({ hash: steps[0].key });
+      history.replace({ hash: steps[0].key, state: locationState });
     }
   }, [activeStep, history, steps]);
 


### PR DESCRIPTION
# CAVEAT
Check validation plan comment at the bottom to weigh in on discovered bugs before merging.

## Background
When refreshing on the Roster page and then hitting "Add Record", an error was shown. This was due to a bug in `CreateRecord.tsx` that wiped some state associated with the `history`. (Thanks @jlhogan for the fix!)

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1272

## Associated PRs
N/A

## Validation Plan
Followed reproduction steps in the issue and validated that the bug is no longer.

## Automated Testing
- [ ] All unit tests are passing.
- [ ] All e2e tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset.
- [ ] If applicable, e2e tests have been added to cover this changeset.

## Additional Context
If there's anything additional information that those reviewing or validating this work should be aware of, please specify it here.