### PR TITLE
Centralize admin redirect to router

### DIFF
--- a/client/src/containers/App/AdminRedirect.tsx
+++ b/client/src/containers/App/AdminRedirect.tsx
@@ -1,0 +1,14 @@
+import React, { useContext } from 'react';
+import UserContext from '../../contexts/UserContext/UserContext';
+import { LoadingWrapper } from '@ctoec/component-library';
+import { Redirect } from 'react-router-dom';
+
+export const AdminRedirect: React.FC = ({ children }) => {
+  const { loading, user } = useContext(UserContext);
+
+  if (loading) {
+    return <LoadingWrapper loading={true} />;
+  }
+
+  return user?.isAdmin ? <>{children}</> : <Redirect to="/" />;
+};

--- a/client/src/containers/App/MakeRouteWithSubroute.tsx
+++ b/client/src/containers/App/MakeRouteWithSubroute.tsx
@@ -3,6 +3,7 @@ import { Route } from 'react-router-dom';
 import { RouteConfig } from '../../routes';
 import { ConfidentialityAgreement } from './ConfidentialityAgreement';
 import { NotSignedInRedirect } from './NotSignedInRedirect';
+import { AdminRedirect } from './AdminRedirect';
 
 // Derived from: https://www.freecodecamp.org/news/hitchhikers-guide-to-react-router-v4-c98c39892399/
 
@@ -15,13 +16,19 @@ const MakeRouteWithSubRoutes = (route: RouteConfig) => {
         const component = (
           <route.component {...props} {...route.props} routes={route.routes} />
         );
-        return route.unauthorized ? (
+        
+        let renderedComponent = route.unauthorized ? (
           component
         ) : (
           <NotSignedInRedirect>
             <ConfidentialityAgreement>{component}</ConfidentialityAgreement>
           </NotSignedInRedirect>
         );
+        renderedComponent = route.adminOnly ? (
+          <AdminRedirect>{renderedComponent}</AdminRedirect>
+        ) : renderedComponent;
+        
+        return renderedComponent;
       }}
     />
   );

--- a/client/src/containers/Organizations/Organizations.tsx
+++ b/client/src/containers/Organizations/Organizations.tsx
@@ -36,9 +36,7 @@ const Organizations: React.FC = () => {
     })();
   }, [user, accessToken]);
 
-  return !user?.isAdmin ? (
-    <Redirect to="/home" />
-  ) : (
+  return (
     <div className="grid-container">
       {alertElements.length > 0 && alertElements}
       <div className="grid-row grid-gap">

--- a/client/src/containers/Overview/Overview.tsx
+++ b/client/src/containers/Overview/Overview.tsx
@@ -28,9 +28,7 @@ const Overview: React.FC = () => {
   const totalSites =
     completedSites.length + inProgressSites.length + noDataSites.length;
 
-  return !user?.isAdmin ? (
-    <Redirect to="/home" />
-  ) : (
+  return (
     <div className="grid-container">
       <div className="grid-row grid-gap">
         <div className="tablet:grid-col-12 margin-top-4 margin-bottom-2">

--- a/client/src/containers/Users/EditUser.tsx
+++ b/client/src/containers/Users/EditUser.tsx
@@ -62,9 +62,7 @@ const EditUser: React.FC = () => {
     });
   };
 
-  return !adminUser?.isAdmin ? (
-    <Redirect to="/home" />
-  ) : (
+  return (
     <div className="grid-container">
       <div className="grid-row grid-gap">
         <div className="tablet:grid-col-12 margin-top-4 margin-bottom-2">

--- a/client/src/containers/Users/Users.tsx
+++ b/client/src/containers/Users/Users.tsx
@@ -26,9 +26,7 @@ const Users: React.FC = () => {
     })();
   }, [user, accessToken]);
 
-  return !user?.isAdmin ? (
-    <Redirect to="/home" />
-  ) : (
+  return (
     <div className="grid-container">
       <div className="grid-row grid-gap">
         {alertElements}

--- a/client/src/routes.ts
+++ b/client/src/routes.ts
@@ -32,6 +32,7 @@ export type RouteConfig = {
   routes?: RouteConfig[];
   unauthorized?: boolean;
   props?: any;
+  adminOnly?: boolean;
 };
 
 export const routes: RouteConfig[] = [
@@ -62,37 +63,44 @@ export const routes: RouteConfig[] = [
     component: Overview,
     unauthorized: false,
     exact: true,
+    adminOnly: true,
   },
   {
     path: '/overview/site/:id',
     component: SiteOverview,
     unauthorized: false,
+    adminOnly: true,
   },
   {
     path: '/organizations',
     component: Organizations,
     unauthorized: false,
+    adminOnly: true,
   },
   {
     path: '/users',
     component: Users,
     unauthorized: false,
+    adminOnly: true,
   },
   {
     path: '/overview/organization/:id',
     component: OrganizationOverview,
     unauthorized: false,
+    adminOnly: true,
   },
   {
     path: '/create-org',
     component: CreateOrg,
     unauthorized: false,
     exact: true,
+    adminOnly: true,
   },
   {
     path: '/edit-user/:id',
     component: EditUser,
     unauthorized: false,
+    adminOnly: true,
   },
   {
     path: '/home',


### PR DESCRIPTION
## Background
This PR moves the handling of whether or not a user is an admin from the individual components to the centralized router. We no longer need to check this at every page/component-level because the router will handle it for us with a redirect.

## GitHub Issue
https://github.com/ctoec/data-collection/issues/1347

## Validation Plan
Log in as an admin user and ensure you can reach:
- [ ] Overview page
- [ ] Organizations summary view page
- [ ] Users summary view page
- [ ] Edit user page

Now, log in as a non-admin user, and ensure you can reach:
- [ ] Home
- [ ] File upload
- [ ] Roster
- [ ] Create record
- [ ] Batch edit
- [ ] Edit record

Additionally, ensure that non-admin users cannot reach (via direct page navigation) any of the admin pages:
- [ ] Overview page
- [ ] Organizations summary view page
- [ ] Users summary view page
- [ ] Edit user page

## Automated Testing
- [ ] All unit tests are passing.
- [ ] If applicable, unit tests have been added to cover this changeset.

## Additional Context
This changeset doesn't affect routes that have `unauthorized: true`, because if we're not securing them then it doesn't matter if admins and non-admins can both reach them (this is true for pages like privacy policy and data template).